### PR TITLE
Add `ZyanStringWrapEx` function

### DIFF
--- a/include/Zycore/String.h
+++ b/include/Zycore/String.h
@@ -400,6 +400,26 @@ ZYCORE_EXPORT ZyanStatus ZyanStringConcatCustomBuffer(ZyanString* destination, c
 ZYCORE_EXPORT ZyanStatus ZyanStringWrap(ZyanString* string, const char* value);
 
 /**
+ * @brief   Initializes the given `ZyanString` instance by wrapping a given string and its length.
+ *
+ * @param   string  A pointer to the `ZyanString` instance.
+ * @param   value   The string.
+ * @param   length  The size of the string.
+ *
+ * @return  A zyan status code.
+ *
+ * The given string does not have to be '\0' terminated, since `length` is used instead of calling
+ * `strlen`.
+ *
+ * The difference between this function and `ZyanStringInitCustomBuffer` is that
+ * `ZyanStringInitCustomBuffer` uses the given space for storage, overriding it.
+ * This function is basically turns the `string` to a view of the given memory location.
+ *
+ * Strings created by this function are IMMUTABLE and do not need finalization.
+ */
+ZYCORE_EXPORT ZyanStatus ZyanStringWrapEx(ZyanString* string, const char* value, ZyanUSize length);
+
+/**
  * @brief   Returns the C-style string of the given `ZyanString` instance.
  *
  * @param   string  A pointer to the `ZyanString` instance.

--- a/include/Zycore/String.h
+++ b/include/Zycore/String.h
@@ -413,7 +413,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringWrap(ZyanString* string, const char* value);
  *
  * The difference between this function and `ZyanStringInitCustomBuffer` is that
  * `ZyanStringInitCustomBuffer` uses the given space for storage, overriding it.
- * This function is basically turns the `string` to a view of the given memory location.
+ * This function basically turns the `string` to a view of the given memory location.
  *
  * Strings created by this function are IMMUTABLE and do not need finalization.
  */

--- a/src/String.c
+++ b/src/String.c
@@ -246,19 +246,24 @@ ZyanStatus ZyanStringConcatCustomBuffer(ZyanString* destination, const ZyanStrin
 
 ZyanStatus ZyanStringWrap(ZyanString* string, const char* value)
 {
+    return ZyanStringWrapEx(string, value, ZYAN_STRLEN(value) + 1);
+}
+
+ZyanStatus ZyanStringWrapEx(ZyanString* string, const char* value, ZyanUSize length)
+{
     if (!string)
     {
         return ZYAN_STATUS_INVALID_ARGUMENT;
     }
 
-    string->flags                   = ZYAN_STRING_IS_IMMUTABLE;
-    string->data.allocator          = ZYAN_NULL;
-    string->data.growth_factor      = 1.0f;
-    string->data.shrink_threshold   = 0.0f;
-    string->data.size               = ZYAN_STRLEN(value) + 1;
-    string->data.capacity           = string->data.size;
-    string->data.element_size       = sizeof(char);
-    string->data.data               = (void*)value;
+    string->flags                 = ZYAN_STRING_IS_IMMUTABLE;
+    string->data.allocator        = ZYAN_NULL;
+    string->data.growth_factor    = 1.0f;
+    string->data.shrink_threshold = 0.0f;
+    string->data.size             = length;
+    string->data.capacity         = string->data.size;
+    string->data.element_size     = sizeof(char);
+    string->data.data             = (void*)value;
 
     // Some of the string code relies on `sizeof(char) == 1`
     ZYAN_ASSERT(string->data.element_size == 1);


### PR DESCRIPTION
This function can be used to create views into strings that are not zero
terminated, but whose length is known (i.e. strings from rust).