### PR TITLE
Prevent overly clever compiler optimizations #if ZYAN_NO_LIBC

### DIFF
--- a/include/Zycore/LibC.h
+++ b/include/Zycore/LibC.h
@@ -267,7 +267,7 @@ ZYAN_INLINE int ZYAN_MEMCMP(const void* s1, const void* s2, ZyanUSize n)
 
 ZYAN_INLINE void* ZYAN_MEMCPY(void* dst, const void* src, ZyanUSize n)
 {
-    ZyanU8* dp = dst;
+    volatile ZyanU8* dp = dst;
     const ZyanU8* sp = src;
     while (n--)
     {
@@ -278,7 +278,7 @@ ZYAN_INLINE void* ZYAN_MEMCPY(void* dst, const void* src, ZyanUSize n)
 
 ZYAN_INLINE void* ZYAN_MEMMOVE(void* dst, const void* src, ZyanUSize n)
 {
-    ZyanU8* pd = dst;
+    volatile ZyanU8* pd = dst;
     const ZyanU8* ps = src;
     if (ps < pd)
     {
@@ -298,7 +298,7 @@ ZYAN_INLINE void* ZYAN_MEMMOVE(void* dst, const void* src, ZyanUSize n)
 
 ZYAN_INLINE void* ZYAN_MEMSET(void* dst, int val, ZyanUSize n)
 {
-    ZyanU8* p = dst;
+    volatile ZyanU8* p = dst;
     while (n--)
     {
         *p++ = (unsigned char)val;


### PR DESCRIPTION
The compiler in question is MSVC, but it seems plausible that other compilers might do this as well. Basically I've been developing a UEFI driver that uses Zydis (with excellent results btw, if you'll take my word for it I can honestly say that I've abused Zydis in very many ways and haven't seen a single issue. So go add UEFI to the list of supported/tested platforms in the README already :wink:)

Today I hit this little snag:
```
EfiGuardDxe.lib(Utils.obj) : error LNK2001: unresolved external symbol memset
c:\dev\efi\workspace\Build\EfiGuard\RELEASE_VS2017\X64\EfiGuardPkg\EfiGuardDxe\EfiGuardDxe\DEBUG\EfiGuardDxe.dll : fatal error LNK1120: 1 unresolved externals
```
This is due to MSVC being clever (well OK... I'll admit it's pretty clever, but not helpful here) and wholesale replacing `ZYAN_MEMCPY` with a `memcpy` intrinsic. 'Intrinsic' is what the documentation calls this, but I'm pretty sure calling a function in some other library doesn't count as an intrinsic but just as laziness.

Whatever the case may be, UEFI applications/drivers may only be linked statically, and cannot import functions from shared libraries because the DXE core image loader is extremely basic and has no support for imports. So I fixed this by adding a few `volatile`s to prevent MSVC and others from doing this again in future.

UEFI, and the WDK for that matter, do have 'proper' replacement functions that should preferably be used instead of this. I might try my hand at adding support for some more CRT-less platforms to `LibC.h` in the future. The WDK should be really easy honestly; the kernel actually implements a good subset of libc/the CRT. UEFI on the other hand... there's about five different implementations of each library, and including anything from EDK2 out-of-tree is a very bad idea. Not sure what can be done about that really.