### PR TITLE
Improved platform support

### DIFF
--- a/include/Zycore/Defines.h
+++ b/include/Zycore/Defines.h
@@ -56,7 +56,14 @@
 /* Platform detection                                                                             */
 /* ============================================================================================== */
 
-#if defined(_WIN32)
+// Unfortunately neither EDK2 nor gnu-efi have any specific defines as part of their build environment, so we have to rely on standard headers.
+// The best solution is to define ZYAN_UEFI in your CMakeLists.txt or project file in order to avoid these hidden header dependencies.
+#if (defined(ZYAN_UEFI) || defined(__PI_UEFI_H__) || defined(_GNU_EFI) || \
+    defined(EFI32) || defined(EFIX64))
+#   ifndef ZYAN_UEFI
+#       define ZYAN_UEFI
+#   endif
+#elif defined(_WIN32)
 #   define ZYAN_WINDOWS
 #elif defined(__EMSCRIPTEN__)
 #   define ZYAN_EMSCRIPTEN
@@ -73,6 +80,19 @@
 #   define ZYAN_POSIX
 #else
 #   define ZYAN_UNKNOWN_PLATFORM
+#endif
+
+/* ============================================================================================== */
+/* Kernel mode detection                                                                          */
+/* ============================================================================================== */
+#if (defined(ZYAN_WINDOWS) && defined(_KERNEL_MODE)) || \
+    (defined(ZYAN_APPLE) && defined(KERNEL)) || \
+    (defined(ZYAN_LINUX) && defined(__KERNEL__)) || \
+    (defined(__FreeBSD_kernel__)) || \
+    (defined(ZYAN_UEFI))
+#   define ZYAN_KERNEL
+#else
+#   define ZYAN_USER
 #endif
 
 /* ============================================================================================== */

--- a/include/Zycore/Defines.h
+++ b/include/Zycore/Defines.h
@@ -152,6 +152,11 @@
  */
 #if defined(ZYAN_NO_LIBC)
 #   define ZYAN_ASSERT(condition)
+#elif (defined(ZYAN_WINDOWS) && defined(ZYAN_KERNEL))
+#   include <wdm.h>
+#   define ZYAN_ASSERT(condition) NT_ASSERT(condition)
+#elif defined(ZYAN_UEFI)
+#   define ZYAN_ASSERT(condition) ASSERT(condition)
 #else
 #   include <assert.h>
 #   define ZYAN_ASSERT(condition) assert(condition)
@@ -192,6 +197,10 @@
 #   endif
 #elif defined(ZYAN_NO_LIBC)
 #   define ZYAN_UNREACHABLE for(;;)
+#elif (defined(ZYAN_WINDOWS) && defined(ZYAN_KERNEL))
+#   define ZYAN_UNREACHABLE { __fastfail(0); for(;;){} }
+#elif (defined(ZYAN_UEFI) && defined(UNREACHABLE)) // EDK2 has this; gnu-efi does not
+#   define ZYAN_UNREACHABLE UNREACHABLE()
 #else
 #   include <stdlib.h>
 #   define ZYAN_UNREACHABLE { assert(0); abort(); }

--- a/include/Zycore/LibC.h
+++ b/include/Zycore/LibC.h
@@ -83,7 +83,6 @@ typedef va_list ZyanVAList;
 #define ZYAN_PUTS       puts
 #define ZYAN_SCANF      scanf
 #define ZYAN_SSCANF     sscanf
-#define ZYAN_VSNPRINTF  vsnprintf
 #if (defined(ZYAN_MSVC) && defined(ZYAN_KERNEL))
 #   define ZYAN_VSNPRINTF  _vsnprintf
 #else

--- a/include/Zycore/LibC.h
+++ b/include/Zycore/LibC.h
@@ -32,6 +32,8 @@
 #ifndef ZYCORE_LIBC_H
 #define ZYCORE_LIBC_H
 
+#include <Zycore/Defines.h>
+
 #ifndef ZYAN_CUSTOM_LIBC
 
 // Include a custom LibC header and define `ZYAN_CUSTOM_LIBC` to provide your own LibC
@@ -82,6 +84,11 @@ typedef va_list ZyanVAList;
 #define ZYAN_SCANF      scanf
 #define ZYAN_SSCANF     sscanf
 #define ZYAN_VSNPRINTF  vsnprintf
+#if (defined(ZYAN_MSVC) && defined(ZYAN_KERNEL))
+#   define ZYAN_VSNPRINTF  _vsnprintf
+#else
+#   define ZYAN_VSNPRINTF  vsnprintf
+#endif
 
 /**
  * @brief   Defines the `ZyanFile` datatype.

--- a/include/Zycore/LibC.h
+++ b/include/Zycore/LibC.h
@@ -253,6 +253,8 @@ ZYAN_INLINE void* ZYAN_MEMCHR(const void* str, int c, ZyanUSize n)
     return 0;
 }
 
+#ifndef ZYAN_UEFI
+
 ZYAN_INLINE int ZYAN_MEMCMP(const void* s1, const void* s2, ZyanUSize n)
 {
     const ZyanU8* p1 = s1, *p2 = s2;
@@ -307,6 +309,24 @@ ZYAN_INLINE void* ZYAN_MEMSET(void* dst, int val, ZyanUSize n)
     }
     return dst;
 }
+
+#else
+
+/*
+ * NOTE: You may get compilation errors from these defines, because they require headers that may or
+ * may not already have been included. Unfortunately, while the function names are defined by the UEFI spec,
+ * the names of the header files are left up to the library implementation.
+ */
+
+//#include <Library/BaseMemoryLib.h>  // For EDK2
+//#include <efilib.h>                 // For gnu-efi
+
+#define ZYAN_MEMCMP                 CompareMem
+#define ZYAN_MEMCPY                 CopyMem
+#define ZYAN_MEMMOVE                CopyMem // CopyMem() is required to deal with overlapping source and destination pointers.
+#define ZYAN_MEMSET(dst, val, n)    SetMem(dst, n, (ZyanU8)val)
+
+#endif // ZYAN_UEFI
 
 ZYAN_INLINE char* ZYAN_STRCAT(char* dest, const char* src)
 {

--- a/include/Zycore/LibC.h
+++ b/include/Zycore/LibC.h
@@ -156,7 +156,7 @@ typedef FILE ZyanFile;
 /* stdarg.h                                                                                       */
 /* ---------------------------------------------------------------------------------------------- */
 
-#if defined(ZYAN_MSVC)
+#if (defined(ZYAN_MSVC) || defined(ZYAN_ICC))
 
 /**
  * @brief   Defines the `ZyanVAList` datatype.

--- a/include/Zycore/Terminal.h
+++ b/include/Zycore/Terminal.h
@@ -40,7 +40,7 @@
 extern "C" {
 #endif
 
-#ifndef ZYAN_NO_LIBC
+#ifdef ZYAN_USER
 
 /* ============================================================================================== */
 /* VT100 CSI SGR sequences                                                                        */
@@ -154,7 +154,7 @@ ZYCORE_EXPORT ZyanStatus ZyanTerminalIsTTY(ZyanStandardStream stream);
 
 /* ============================================================================================== */
 
-#endif // ZYAN_NO_LIBC
+#endif // ZYAN_USER
 
 #ifdef __cplusplus
 }

--- a/include/Zycore/Types.h
+++ b/include/Zycore/Types.h
@@ -56,7 +56,7 @@
     typedef intptr_t  ZyanIPointer;
 #else
     // No LibC, use compiler built-in types / macros.
-#   if defined(ZYAN_MSVC)
+#   if (defined(ZYAN_MSVC) || defined(ZYAN_ICC))
         typedef unsigned __int8  ZyanU8;
         typedef unsigned __int16 ZyanU16;
         typedef unsigned __int32 ZyanU32;

--- a/include/Zycore/Types.h
+++ b/include/Zycore/Types.h
@@ -38,7 +38,7 @@
 /* Integer types                                                                                  */
 /* ============================================================================================== */
 
-#if !defined(ZYAN_NO_LIBC)
+#if !defined(ZYAN_NO_LIBC) && (!defined(ZYAN_MSVC) && defined(ZYAN_KERNEL)) // The WDK LibC lacks stdint.h.
     // If is LibC present, we use stdint types.
 #   include <stdint.h>
 #   include <stddef.h>

--- a/src/Terminal.c
+++ b/src/Terminal.c
@@ -26,7 +26,7 @@
 
 #include <Zycore/Terminal.h>
 
-#ifndef ZYAN_NO_LIBC
+#ifdef ZYAN_USER
 
 #ifdef ZYAN_WINDOWS
 #   include <Windows.h>
@@ -155,4 +155,4 @@ ZyanStatus ZyanTerminalIsTTY(ZyanStandardStream stream)
 
 /* ============================================================================================== */
 
-#endif // ZYAN_NO_LIBC
+#endif // ZYAN_USER


### PR DESCRIPTION
This is a first attempt at introducing some better platform detection and compatibility/support, inspired by the discussion on #6.

The most important change I feel is the addition of user vs kernel mode detection, since IMO 'LibC or not' does not cover all cases well enough. For example, I write nearly all my user mode programs using only the native Windows API, meaning no LibC. However I can happily call `malloc` as much as I want (sure, I have to call `RtlAllocateHeap` in `ntdll.dll`, but it's the same thing under the hood). In kernel mode on the other hand, I have access to a large subset of the standard C library, but I would still rather return failure than call a faux `malloc` stand-in that has a minimum allocation granularity of 4KB just to grow a string buffer or whatever other noncritical task.

One place where I already changed the 'no LibC vs kernel mode' logic is `Terminal.c/.h`. With these changes I can link against `Zycore.lib` in the `ZydisWinKernel` sample **without** defining `ZYAN_NO_LIBC` and use types like `ZyanVAList` and the `ZYAN_VA_START/END` and `ZYAN_ASSERT` macros, which was absolutely impossible before.

With kernel mode detection also comes by necessity UEFI detection, which is unfortunately not so simple to do because of differences in library implementations. I think that for UEFI specifically a `CMakeLists.txt` flag is warranted, since standalone Zydis source files may call e.g. `ZYAN_MEMSET` and obviously cannot be expected to include any UEFI headers 'just in case' (if they even could - and not to mention the filenames of these headers are also implementation dependent... lovely).

As a bonus, the Intel compiler can now also compile all of Zycore, Zydis and the Zydis samples thanks to two added ifdefs! This functionality is not really useful in practice unless you like binaries that are twice the usual size.