### PR TITLE
Add ZYAN_PRINTF_ATTR and ZYAN_WPRINTF_ATTR

### DIFF
--- a/include/Zycore/Defines.h
+++ b/include/Zycore/Defines.h
@@ -234,6 +234,32 @@
  */
 #define ZYAN_REQUIRES_LIBC
 
+/**
+ * @brief   Decorator for `printf`-style functions.
+ *
+ * @param   fmtIndex       The 1-based index of the format string parameter.
+ * @param   firstToCheck   The 1-based index of the format arguments parameter.
+ */
+#if defined(__RESHARPER__) || defined(ZYAN_GCC)
+#define ZYAN_PRINTF_ATTR(fmtIndex, firstToCheck) \
+    [[gnu::format(printf, fmtIndex, firstToCheck)]]
+#else
+#define ZYAN_PRINTF_ATTR(fmtIndex, firstToCheck)
+#endif
+
+/**
+ * @brief   Decorator for `wprintf`-style functions.
+ *
+ * @param   fmtIndex       The 1-based index of the format string parameter.
+ * @param   firstToCheck   The 1-based index of the format arguments parameter.
+ */
+#if defined(__RESHARPER__)
+#define ZYAN_WPRINTF_ATTR(fmtIndex, firstToCheck) \
+    [[rscpp::format(wprintf, fmtIndex, firstToCheck)]]
+#else
+#define ZYAN_WPRINTF_ATTR(fmtIndex, firstToCheck)
+#endif
+
 /* ---------------------------------------------------------------------------------------------- */
 /* Arrays                                                                                         */
 /* ---------------------------------------------------------------------------------------------- */

--- a/include/Zycore/Format.h
+++ b/include/Zycore/Format.h
@@ -62,6 +62,7 @@ extern "C" {
  * This function will fail, if the `ZYAN_STRING_IS_IMMUTABLE` flag is set for the specified
  * `ZyanString` instance.
  */
+ZYAN_PRINTF_ATTR(3, 4)
 ZYCORE_EXPORT ZyanStatus ZyanStringInsertFormat(ZyanString* string, ZyanUSize index,
     const char* format, ...);
 
@@ -165,6 +166,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringInsertHexS(ZyanString* string, ZyanUSize inde
  * This function will fail, if the `ZYAN_STRING_IS_IMMUTABLE` flag is set for the specified
  * `ZyanString` instance.
  */
+ZYAN_PRINTF_ATTR(2, 3)
 ZYCORE_EXPORT ZYAN_REQUIRES_LIBC ZyanStatus ZyanStringAppendFormat(
     ZyanString* string, const char* format, ...);
 


### PR DESCRIPTION
This adds two decorators named `ZYAN_PRINTF_ATTR` and `ZYAN_WPRINTF_ATTR`. The former is used to decorate `ZyanStringInsertFormat` and `ZyanStringAppendFormat` for type checking (GCC and Resharper) and syntax highlighting (Resharper) of varargs arguments.