### PR TITLE
WIP: Webassembly support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,15 +135,16 @@ generate_export_header("Zycore" BASE_NAME "ZYCORE" EXPORT_FILE_NAME "ZycoreExpor
 
 if (ZYAN_NO_LIBC)
     target_compile_definitions("Zycore" PUBLIC "ZYAN_NO_LIBC")
+    if (UNIX)
+        target_compile_options("Zycore" PUBLIC "-nostdlib" "-nodefaultlibs")
+    endif ()
 endif ()
 
 target_sources("Zycore"
     PRIVATE
         # API
         "${CMAKE_CURRENT_LIST_DIR}/include/Zycore/API/Memory.h"
-        "${CMAKE_CURRENT_LIST_DIR}/include/Zycore/API/Synchronization.h"
         "${CMAKE_CURRENT_LIST_DIR}/include/Zycore/API/Terminal.h"
-        "${CMAKE_CURRENT_LIST_DIR}/include/Zycore/API/Thread.h"
         # Common
         "${CMAKE_CURRENT_LIST_DIR}/include/Zycore/Allocator.h"
         "${CMAKE_CURRENT_LIST_DIR}/include/Zycore/Bitset.h"
@@ -160,9 +161,7 @@ target_sources("Zycore"
         "${CMAKE_CURRENT_LIST_DIR}/include/Zycore/Zycore.h"
         # API
         "src/API/Memory.c"
-        "src/API/Synchronization.c"
         "src/API/Terminal.c"
-        "src/API/Thread.c"
         # Common
         "src/Allocator.c"
         "src/Bitset.c"
@@ -172,13 +171,23 @@ target_sources("Zycore"
         "src/Vector.c"
         "src/Zycore.c")
 
+if (NOT ZYAN_NO_LIBC)
+    target_sources("Zycore"
+        PRIVATE
+            # API
+            "${CMAKE_CURRENT_LIST_DIR}/include/Zycore/API/Synchronization.h"
+            "${CMAKE_CURRENT_LIST_DIR}/include/Zycore/API/Thread.h"
+            "src/API/Synchronization.c"
+            "src/API/Thread.c")
+endif ()
+
 if (ZYCORE_BUILD_SHARED_LIB AND WIN32)
     target_sources("Zycore" PRIVATE "resources/VersionInfo.rc")
 endif ()
 
 zyan_set_source_group("Zycore")
 
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND NOT ZYAN_NO_LIBC)
     target_compile_definitions("Zycore" PRIVATE "_GNU_SOURCE")
     find_package(Threads REQUIRED)
     target_link_libraries("Zycore" Threads::Threads)

--- a/WASMToolchain.cmake
+++ b/WASMToolchain.cmake
@@ -1,0 +1,15 @@
+set(CMAKE_SYSTEM_NAME "wasm32-unknown-wasi")
+
+set(CMAKE_C_COMPILER "clang")
+set(CMAKE_CXX_COMPILER "clang")
+
+set(CMAKE_C_COMPILER_WORKS 1)
+set(CMAKE_CXX_COMPILER_WORKS 1)
+
+# Using <FLAGS>, <TARGET>, <CMAKE_C_LINK_FLAGS> and <LINK_FLAGS> breaks it
+set(CMAKE_C_LINK_EXECUTABLE
+  "wasm-ld <OBJECTS> -o <LINK_LIBRARIES>")
+set(CMAKE_CXX_LINK_EXECUTABLE
+  "wasm-ld <OBJECTS> -o <LINK_LIBRARIES>")
+
+add_definitions("-DZYAN_WASM")

--- a/include/Zycore/Defines.h
+++ b/include/Zycore/Defines.h
@@ -130,6 +130,8 @@
 #   define ZYAN_ARM
 #elif defined(__EMSCRIPTEN__)
     // Nothing to do, `ZYAN_EMSCRIPTEN` is both platform and arch macro for this one.
+#elif defined(ZYAN_WASM)
+    // Nothing to do.
 #else
 #   error "Unsupported architecture detected"
 #endif

--- a/src/Format.c
+++ b/src/Format.c
@@ -83,7 +83,7 @@ static const ZyanStringView STR_SUB = ZYAN_DEFINE_STRING_VIEW("-");
 /* Decimal                                                                                        */
 /* ---------------------------------------------------------------------------------------------- */
 
-#if defined(ZYAN_X86) || defined(ZYAN_ARM) || defined(ZYAN_EMSCRIPTEN)
+#if defined(ZYAN_X86) || defined(ZYAN_ARM) || defined(ZYAN_EMSCRIPTEN) || defined(ZYAN_WASM)
 ZyanStatus ZyanStringAppendDecU32(ZyanString* string, ZyanU32 value, ZyanU8 padding_length)
 {
     if (!string)
@@ -179,7 +179,7 @@ ZyanStatus ZyanStringAppendDecU64(ZyanString* string, ZyanU64 value, ZyanU8 padd
 /* Hexadecimal                                                                                    */
 /* ---------------------------------------------------------------------------------------------- */
 
-#if defined(ZYAN_X86) || defined(ZYAN_ARM) || defined(ZYAN_EMSCRIPTEN)
+#if defined(ZYAN_X86) || defined(ZYAN_ARM) || defined(ZYAN_EMSCRIPTEN) || defined(ZYAN_WASM)
 ZyanStatus ZyanStringAppendHexU32(ZyanString* string, ZyanU32 value, ZyanU8 padding_length,
     ZyanBool uppercase)
 {


### PR DESCRIPTION
This seems to build correctly with some patches to the rust bindings and then compiling with `cargo run --example simple --features wasm --target wasm32-unknown-wasi`.

Requires clang and the `libclang_rt.builtins-wasm32.a` file in `/usr/lib/clang/8.0.0/lib/wasi/libclang_rt.builtins-wasm32.a`. That file can be download [here](https://github.com/jedisct1/libclang_rt.builtins-wasm32.a/tree/master/precompiled)

Example invocation from the `build` dir:
```
cmake -DCMAKE_C_FLAGS="--target=wasm32-unknown-wasi" -DCMAKE_CXX_FLAGS="--target=wasm32-unknown-wasi" -DCMAKE_TOOLCHAIN_FILE=../WASMToolchain.cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=O
N -DCMAKE_BUILD_TYPE=Debug -DZYAN_NO_LIBC=ON -DZYCORE_BUILD_SHARED_LIB=OFF -G Ninja
```