### PR TITLE
Fix to allow compilation with MinGW

### DIFF
--- a/include/Zycore/API/Synchronization.h
+++ b/include/Zycore/API/Synchronization.h
@@ -60,7 +60,7 @@ typedef pthread_mutex_t ZyanCriticalSection;
 
 #elif defined(ZYAN_WINDOWS)
 
-#include <Windows.h>
+#include <windows.h>
 
 /* ---------------------------------------------------------------------------------------------- */
 /* Critical Section                                                                               */

--- a/include/Zycore/API/Thread.h
+++ b/include/Zycore/API/Thread.h
@@ -92,7 +92,7 @@ typedef void(*ZyanThreadTlsCallback)(void* data);
 
 #elif defined(ZYAN_WINDOWS)
 
-#include <Windows.h>
+#include <windows.h>
 
 /* ---------------------------------------------------------------------------------------------- */
 /* General                                                                                        */

--- a/src/API/Terminal.c
+++ b/src/API/Terminal.c
@@ -29,7 +29,7 @@
 #if   defined(ZYAN_POSIX)
 #   include <unistd.h>
 #elif defined(ZYAN_WINDOWS)
-#   include <Windows.h>
+#   include <windows.h>
 #   include <io.h>
 #else
 #   error "Unsupported platform detected"


### PR DESCRIPTION
MinGW is case sensitive when including files, and it ships the main Windows header as `windows.h`.

This patch converts every reference of the Windows header to lower case.

I ran tests on both MinGW and MSVC successfully.

I used MinGW version 9.2.0 and MSVC 2017 version 15.9.8, in a Windows 10 virtual machine.
Each compiler generated binaries targeting 32 and 64 bits platforms in Release mode.