### PR TITLE
Allow to build with C++ (_Static_assert not defined by C++)

### DIFF
--- a/include/Zycore/Defines.h
+++ b/include/Zycore/Defines.h
@@ -187,8 +187,12 @@
 /**
  * @brief   Compiler-time assertion.
  */
-#if __STDC_VERSION__ >= 201112L
+#if __STDC_VERSION__ >= 201112L && !defined(__cplusplus)
 #   define ZYAN_STATIC_ASSERT(x) _Static_assert(x, #x)
+#elif (defined(__cplusplus) && __cplusplus >= 201103L) || \
+      (defined(__cplusplus) && defined (_MSC_VER) && (_MSC_VER >= 1600)) || \
+      (defined (_MSC_VER) && (_MSC_VER >= 1800))
+#   define ZYAN_STATIC_ASSERT(x) static_assert(x, #x)
 #else
 #   define ZYAN_STATIC_ASSERT(x) \
         typedef int ZYAN_MACRO_CONCAT_EXPAND(ZYAN_SASSERT_, __COUNTER__) [(x) ? 1 : -1]


### PR DESCRIPTION
Should fix Firefox build with GCC: https://bugzilla.mozilla.org/show_bug.cgi?id=1604740