### PR TITLE
Use auto-brief doxygen syntax

### DIFF
--- a/examples/String.c
+++ b/examples/String.c
@@ -26,7 +26,7 @@
 
 /**
  * @file
- * @brief   Demonstrates the `String` implementation.
+ * Demonstrates the `String` implementation.
  */
 
 #include <stdio.h>
@@ -54,7 +54,7 @@
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Performs some basic test on the given `ZyanString` instance.
+ * Performs some basic test on the given `ZyanString` instance.
  *
  * @param   string  A pointer to the `ZyanString` instance.
  *
@@ -71,7 +71,7 @@ static ZyanStatus PerformBasicTests(ZyanString* string)
 }
 
 /**
- * @brief   Performs basic tests on a string that dynamically manages memory.
+ * Performs basic tests on a string that dynamically manages memory.
  *
  * @return  A zyan status code.
  */
@@ -82,7 +82,7 @@ static ZyanStatus TestDynamic(void)
 }
 
 /**
- * @brief   Performs basic tests on a string that uses a static buffer.
+ * Performs basic tests on a string that uses a static buffer.
  *
  * @return  A zyan status code.
  */
@@ -155,8 +155,8 @@ static ZyanStatus TestStatic(void)
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Performs basic tests on a vector that dynamically manages memory using a custom
- *          allocator and modified growth-factor/shrink-threshold.
+ * Performs basic tests on a vector that dynamically manages memory using a custom
+ * allocator and modified growth-factor/shrink-threshold.
  *
  * @return  A zyan status code.
  */

--- a/examples/Vector.c
+++ b/examples/Vector.c
@@ -26,7 +26,7 @@
 
 /**
  * @file
- * @brief   Demonstrates the `ZyanVector` implementation.
+ * Demonstrates the `ZyanVector` implementation.
  */
 
 #include <inttypes.h>
@@ -43,7 +43,7 @@
 /* ============================================================================================== */
 
 /**
- * @brief   Defines the `TestStruct` struct that represents a single element in the vector.
+ * Defines the `TestStruct` struct that represents a single element in the vector.
  */
 typedef struct TestStruct_
 {
@@ -57,7 +57,7 @@ typedef struct TestStruct_
 /* ============================================================================================== */
 
 /**
- * @brief   Initializes the given `TestStruct` struct.
+ * Initializes the given `TestStruct` struct.
  *
  * @param   data    A pointer to the `TestStruct` struct.
  * @param   n       The number to initialize the struct with.
@@ -80,7 +80,7 @@ static void InitTestdata(TestStruct* data, ZyanU32 n)
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Performs some basic test on the given `ZyanVector` instance.
+ * Performs some basic test on the given `ZyanVector` instance.
  *
  * @param   vector  A pointer to the `ZyanVector` instance.
  *
@@ -131,8 +131,8 @@ static ZyanStatus PerformBasicTests(ZyanVector* vector)
 }
 
 /**
- * @brief   A dummy comparison function for the `TestStruct` that uses the `u32` field as key
- *          value.
+ * A dummy comparison function for the `TestStruct` that uses the `u32` field as key
+ * value.
  *
  * @param   left    A pointer to the first element.
  * @param   right   A pointer to the second element.
@@ -159,7 +159,7 @@ static ZyanI32 TestDataComparison(const TestStruct* left, const TestStruct* righ
 }
 
 /**
- * @brief   Tests the binary-search functionality of the given `ZyanVector` instance.
+ * Tests the binary-search functionality of the given `ZyanVector` instance.
  *
  * @param   vector  A pointer to the `ZyanVector` instance.
  *
@@ -200,7 +200,7 @@ static ZyanStatus PerformBinarySearchTest(ZyanVector* vector)
 }
 
 /**
- * @brief   Performs basic tests on a vector that dynamically manages memory.
+ * Performs basic tests on a vector that dynamically manages memory.
  *
  * @return  A zyan status code.
  */
@@ -220,7 +220,7 @@ static ZyanStatus TestDynamic(void)
 }
 
 /**
- * @brief   Performs basic tests on a vector that uses a static buffer.
+ * Performs basic tests on a vector that uses a static buffer.
  *
  * @return  A zyan status code.
  */
@@ -317,8 +317,8 @@ static ZyanStatus AllocatorDeallocate(ZyanAllocator* allocator, void* p, ZyanUSi
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Performs basic tests on a vector that dynamically manages memory using a custom
- *          allocator and modified growth-factor/shrink-threshold.
+ * Performs basic tests on a vector that dynamically manages memory using a custom
+ * allocator and modified growth-factor/shrink-threshold.
  *
  * @return  A zyan status code.
  */
@@ -331,7 +331,7 @@ static ZyanStatus TestAllocator(void)
     // Initialize vector with a base capacity of `10` elements. Growth-factor is set to 10 and
     // dynamic shrinking is disabled
     ZyanVector vector;
-    ZYAN_CHECK(ZyanVectorInitEx(&vector, sizeof(TestStruct), 5, ZYAN_NULL, &allocator, 
+    ZYAN_CHECK(ZyanVectorInitEx(&vector, sizeof(TestStruct), 5, ZYAN_NULL, &allocator,
         10.0f, 0.0f));
 
     static TestStruct  e_v;

--- a/include/Zycore/API/Memory.h
+++ b/include/Zycore/API/Memory.h
@@ -50,23 +50,23 @@
 /* ============================================================================================== */
 
 /**
- * @brief   Defines the `ZyanMemoryPageProtection` enum.  
+ * Defines the `ZyanMemoryPageProtection` enum.
  */
 typedef enum ZyanMemoryPageProtection_
 {
 #if   defined(ZYAN_WINDOWS)
 
-    ZYAN_PAGE_READONLY          = PAGE_READONLY,           
+    ZYAN_PAGE_READONLY          = PAGE_READONLY,
     ZYAN_PAGE_READWRITE         = PAGE_READWRITE,
-    ZYAN_PAGE_EXECUTE           = PAGE_EXECUTE,             
+    ZYAN_PAGE_EXECUTE           = PAGE_EXECUTE,
     ZYAN_PAGE_EXECUTE_READ      = PAGE_EXECUTE_READ,
     ZYAN_PAGE_EXECUTE_READWRITE = PAGE_EXECUTE_READWRITE
 
 #elif defined(ZYAN_POSIX)
 
-    ZYAN_PAGE_READONLY          = PROT_READ,           
+    ZYAN_PAGE_READONLY          = PROT_READ,
     ZYAN_PAGE_READWRITE         = PROT_READ | PROT_WRITE,
-    ZYAN_PAGE_EXECUTE           = PROT_EXEC,             
+    ZYAN_PAGE_EXECUTE           = PROT_EXEC,
     ZYAN_PAGE_EXECUTE_READ      = PROT_EXEC | PROT_READ,
     ZYAN_PAGE_EXECUTE_READWRITE = PROT_EXEC | PROT_READ | PROT_WRITE
 
@@ -82,14 +82,14 @@ typedef enum ZyanMemoryPageProtection_
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Returns the system page size.
+ * Returns the system page size.
  *
  * @return  The system page size.
  */
 ZyanU32 ZyanMemoryGetSystemPageSize();
 
 /**
- * @brief   Returns the system allocation granularity.
+ * Returns the system allocation granularity.
  *
  * The system allocation granularity specifies the minimum amount of bytes which can be allocated
  * at a specific address by a single call of `ZyanMemoryVirtualAlloc`.
@@ -106,7 +106,7 @@ ZyanU32 ZyanMemoryGetSystemAllocationGranularity();
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Changes the memory protection value of one or more pages.
+ * Changes the memory protection value of one or more pages.
  *
  * @param   address     The start address aligned to a page boundary.
  * @param   size        The size.
@@ -114,11 +114,11 @@ ZyanU32 ZyanMemoryGetSystemAllocationGranularity();
  *
  * @return  A zyan status code.
  */
-ZyanStatus ZyanMemoryVirtualProtect(void* address, ZyanUSize size, 
+ZyanStatus ZyanMemoryVirtualProtect(void* address, ZyanUSize size,
     ZyanMemoryPageProtection protection);
 
 /**
- * @brief   Releases one or more memory pages starting at the given address.
+ * Releases one or more memory pages starting at the given address.
  *
  * @param   address The start address aligned to a page boundary.
  * @param   size    The size.

--- a/include/Zycore/API/Synchronization.h
+++ b/include/Zycore/API/Synchronization.h
@@ -83,21 +83,21 @@ typedef CRITICAL_SECTION ZyanCriticalSection;
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Initializes a critical section.
+ * Initializes a critical section.
  *
  * @param   critical_section    A pointer to the `ZyanCriticalSection` struct.
  */
 ZYCORE_EXPORT ZyanStatus ZyanCriticalSectionInitialize(ZyanCriticalSection* critical_section);
 
 /**
- * @brief   Enters a critical section.
+ * Enters a critical section.
  *
  * @param   critical_section    A pointer to the `ZyanCriticalSection` struct.
  */
 ZYCORE_EXPORT ZyanStatus ZyanCriticalSectionEnter(ZyanCriticalSection* critical_section);
 
 /**
- * @brief   Tries to enter a critical section.
+ * Tries to enter a critical section.
  *
  * @param   critical_section    A pointer to the `ZyanCriticalSection` struct.
  *
@@ -107,14 +107,14 @@ ZYCORE_EXPORT ZyanStatus ZyanCriticalSectionEnter(ZyanCriticalSection* critical_
 ZYCORE_EXPORT ZyanBool ZyanCriticalSectionTryEnter(ZyanCriticalSection* critical_section);
 
 /**
- * @brief   Leaves a critical section.
+ * Leaves a critical section.
  *
  * @param   critical_section    A pointer to the `ZyanCriticalSection` struct.
  */
 ZYCORE_EXPORT ZyanStatus ZyanCriticalSectionLeave(ZyanCriticalSection* critical_section);
 
 /**
- * @brief   Deletes a critical section.
+ * Deletes a critical section.
  *
  * @param   critical_section    A pointer to the `ZyanCriticalSection` struct.
  */

--- a/include/Zycore/API/Terminal.h
+++ b/include/Zycore/API/Terminal.h
@@ -105,20 +105,20 @@ extern "C" {
 /* ============================================================================================== */
 
 /**
- * @brief   Declares the `ZyanStandardStream` enum.
+ * Declares the `ZyanStandardStream` enum.
  */
 typedef enum ZyanStandardStream_
 {
     /**
-     * @brief   The default input stream.
+     * The default input stream.
      */
     ZYAN_STDSTREAM_IN,
     /**
-     * @brief   The default output stream.
+     * The default output stream.
      */
     ZYAN_STDSTREAM_OUT,
     /**
-     * @brief   The default error stream.
+     * The default error stream.
      */
     ZYAN_STDSTREAM_ERR
 } ZyanStandardStream;
@@ -128,7 +128,7 @@ typedef enum ZyanStandardStream_
 /* ============================================================================================== */
 
 /**
- * @brief   Enables VT100 ansi escape codes for the given stream.
+ * Enables VT100 ansi escape codes for the given stream.
  *
  * @param   stream  Either `ZYAN_STDSTREAM_OUT` or `ZYAN_STDSTREAM_ERR`.
  *
@@ -143,7 +143,7 @@ typedef enum ZyanStandardStream_
 ZYCORE_EXPORT ZyanStatus ZyanTerminalEnableVT100(ZyanStandardStream stream);
 
 /**
- * @brief   Checks, if the given standard stream reads from or writes to a terminal.
+ * Checks, if the given standard stream reads from or writes to a terminal.
  *
  * @param   stream  The standard stream to check.
  *

--- a/include/Zycore/API/Thread.h
+++ b/include/Zycore/API/Thread.h
@@ -55,12 +55,12 @@ extern "C" {
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- *  @brief  Defines the `ZyanThread` data-type.
+ *  Defines the `ZyanThread` data-type.
  */
 typedef pthread_t ZyanThread;
 
 /**
- *  @brief  Defines the `ZyanThreadId` data-type.
+ *  Defines the `ZyanThreadId` data-type.
  */
 typedef ZyanU64 ZyanThreadId;
 
@@ -69,17 +69,17 @@ typedef ZyanU64 ZyanThreadId;
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- *  @brief  Defines the `ZyanThreadTlsIndex` data-type.
+ *  Defines the `ZyanThreadTlsIndex` data-type.
  */
 typedef pthread_key_t ZyanThreadTlsIndex;
 
 /**
- *  @brief  Defines the `ZyanThreadTlsCallback` function prototype.
+ *  Defines the `ZyanThreadTlsCallback` function prototype.
  */
 typedef void(*ZyanThreadTlsCallback)(void* data);
 
 /**
- * @brief   Declares a Thread Local Storage (TLS) callback function.
+ * Declares a Thread Local Storage (TLS) callback function.
  *
  * @param   name        The callback function name.
  * @param   param_type  The callback data parameter type.
@@ -99,12 +99,12 @@ typedef void(*ZyanThreadTlsCallback)(void* data);
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- *  @brief  Defines the `ZyanThread` data-type.
+ *  Defines the `ZyanThread` data-type.
  */
 typedef HANDLE ZyanThread;
 
 /**
- *  @brief  Defines the `ZyanThreadId` data-type.
+ *  Defines the `ZyanThreadId` data-type.
  */
 typedef DWORD ZyanThreadId;
 
@@ -113,17 +113,17 @@ typedef DWORD ZyanThreadId;
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- *  @brief  Defines the `ZyanThreadTlsIndex` data-type.
+ *  Defines the `ZyanThreadTlsIndex` data-type.
  */
 typedef DWORD ZyanThreadTlsIndex;
 
 /**
- *  @brief  Defines the `ZyanThreadTlsCallback` function prototype.
+ *  Defines the `ZyanThreadTlsCallback` function prototype.
  */
 typedef PFLS_CALLBACK_FUNCTION ZyanThreadTlsCallback;
 
 /**
- * @brief   Declares a Thread Local Storage (TLS) callback function.
+ * Declares a Thread Local Storage (TLS) callback function.
  *
  * @param   name        The callback function name.
  * @param   param_type  The callback data parameter type.
@@ -147,7 +147,7 @@ typedef PFLS_CALLBACK_FUNCTION ZyanThreadTlsCallback;
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Returns the handle of the current thread.
+ * Returns the handle of the current thread.
  *
  * @param   thread  Receives the handle of the current thread.
  *
@@ -156,7 +156,7 @@ typedef PFLS_CALLBACK_FUNCTION ZyanThreadTlsCallback;
 ZYCORE_EXPORT ZyanStatus ZyanThreadGetCurrentThread(ZyanThread* thread);
 
 /**
- * @brief   Returns the unique id of the current thread.
+ * Returns the unique id of the current thread.
  *
  * @param   thread_id   Receives the unique id of the current thread.
  *
@@ -169,7 +169,7 @@ ZYCORE_EXPORT ZyanStatus ZyanThreadGetCurrentThreadId(ZyanThreadId* thread_id);
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Allocates a new Thread Local Storage (TLS) slot.
+ * Allocates a new Thread Local Storage (TLS) slot.
  *
  * @param   index       Receives the TLS slot index.
  * @param   destructor  A pointer to a destructor callback which is invoked to finalize the data
@@ -200,7 +200,7 @@ ZYCORE_EXPORT ZyanStatus ZyanThreadTlsAlloc(ZyanThreadTlsIndex* index,
     ZyanThreadTlsCallback destructor);
 
 /**
- * @brief   Releases a Thread Local Storage (TLS) slot.
+ * Releases a Thread Local Storage (TLS) slot.
  *
  * @param   index   The TLS slot index.
  *
@@ -209,19 +209,19 @@ ZYCORE_EXPORT ZyanStatus ZyanThreadTlsAlloc(ZyanThreadTlsIndex* index,
 ZYCORE_EXPORT ZyanStatus ZyanThreadTlsFree(ZyanThreadTlsIndex index);
 
 /**
- * @brief   Returns the value inside the given Thread Local Storage (TLS) slot for the calling
- *          thread.
+ * Returns the value inside the given Thread Local Storage (TLS) slot for the
+ * calling thread.
  *
  * @param   index   The TLS slot index.
- * @param   data    Receives the value inside the given Thread Local Storage (TLS) slot for the
- *                  calling thread.
+ * @param   data    Receives the value inside the given Thread Local Storage
+ *                  (TLS) slot for the calling thread.
  *
  * @return  A zyan status code.
  */
 ZYCORE_EXPORT ZyanStatus ZyanThreadTlsGetValue(ZyanThreadTlsIndex index, void** data);
 
 /**
- * @brief   Set the value of the given Thread Local Storage (TLS) slot for the calling thread.
+ * Set the value of the given Thread Local Storage (TLS) slot for the calling thread.
  *
  * @param   index   The TLS slot index.
  * @param   data    The value to store inside the given Thread Local Storage (TLS) slot for the

--- a/include/Zycore/Allocator.h
+++ b/include/Zycore/Allocator.h
@@ -47,7 +47,7 @@ extern "C" {
 struct ZyanAllocator_;
 
 /**
- * @brief   Defines the `ZyanAllocatorAllocate` function prototype.
+ * Defines the `ZyanAllocatorAllocate` function prototype.
  *
  * @param   allocator       A pointer to the `ZyanAllocator` instance.
  * @param   p               Receives a pointer to the first memory block sufficient to hold an
@@ -66,7 +66,7 @@ typedef ZyanStatus (*ZyanAllocatorAllocate)(struct ZyanAllocator_* allocator, vo
     ZyanUSize element_size, ZyanUSize n);
 
 /**
- * @brief   Defines the `ZyanAllocatorDeallocate` function prototype.
+ * Defines the `ZyanAllocatorDeallocate` function prototype.
  *
  * @param   allocator       A pointer to the `ZyanAllocator` instance.
  * @param   p               The pointer obtained from `(re-)allocate()`.
@@ -79,7 +79,7 @@ typedef ZyanStatus (*ZyanAllocatorDeallocate)(struct ZyanAllocator_* allocator, 
     ZyanUSize element_size, ZyanUSize n);
 
 /**
- * @brief   Defines the `ZyanAllocator` struct.
+ * Defines the `ZyanAllocator` struct.
  *
  * This is the base class for all custom allocator implementations.
  *
@@ -89,15 +89,15 @@ typedef ZyanStatus (*ZyanAllocatorDeallocate)(struct ZyanAllocator_* allocator, 
 typedef struct ZyanAllocator_
 {
     /**
-     * @brief   The allocate function.
+     * The allocate function.
      */
     ZyanAllocatorAllocate allocate;
     /**
-     * @brief   The reallocate function.
+     * The reallocate function.
      */
     ZyanAllocatorAllocate reallocate;
     /**
-     * @brief   The deallocate function.
+     * The deallocate function.
      */
     ZyanAllocatorDeallocate deallocate;
 } ZyanAllocator;
@@ -107,7 +107,7 @@ typedef struct ZyanAllocator_
 /* ============================================================================================== */
 
 /**
- * @brief   Initializes the given `ZyanAllocator` instance.
+ * Initializes the given `ZyanAllocator` instance.
  *
  * @param   allocator   A pointer to the `ZyanAllocator` instance.
  * @param   allocate    The allocate function.
@@ -122,7 +122,7 @@ ZYCORE_EXPORT ZyanStatus ZyanAllocatorInit(ZyanAllocator* allocator, ZyanAllocat
 #ifndef ZYAN_NO_LIBC
 
 /**
- * @brief   Returns the default `ZyanAllocator` instance.
+ * Returns the default `ZyanAllocator` instance.
  *
  * @return  A pointer to the default `ZyanAllocator` instance.
  *

--- a/include/Zycore/ArgParse.h
+++ b/include/Zycore/ArgParse.h
@@ -26,7 +26,7 @@
 
 /**
  * @file
- * @brief   Implements command-line argument parsing.
+ * Implements command-line argument parsing.
  */
 
 #ifndef ZYCORE_ARGPARSE_H
@@ -46,50 +46,50 @@ extern "C" {
 /* ============================================================================================== */
 
 /**
- * @brief   Definition of a single argument.
+ * Definition of a single argument.
  */
 typedef struct ZyanArgParseDefinition_
 {
     /**
-     * @brief   The argument name, e.g. `--help`.
+     * The argument name, e.g. `--help`.
      *
      * Must start with either one or two dashes. Single dash arguments must consist of a single
      * character, (e.g. `-n`), double-dash arguments can be of arbitrary length.
      */
     const char* name;
     /**
-     * @brief   Whether the argument is boolean or expects a value.
+     * Whether the argument is boolean or expects a value.
      */
     ZyanBool boolean;
     /**
-     * @brief   Whether this argument is required (error if missing).
+     * Whether this argument is required (error if missing).
      */
     ZyanBool required;
 } ZyanArgParseDefinition;
 
 /**
- * @brief   Configuration for argument parsing.
+ * Configuration for argument parsing.
  */
 typedef struct ZyanArgParseConfig_
 {
     /**
-     * @brief   `argv` argument passed to `main` by LibC.
+     * `argv` argument passed to `main` by LibC.
      */
     const char** argv;
     /**
-     * @brief   `argc` argument passed to `main` by LibC.
+     * `argc` argument passed to `main` by LibC.
      */
     ZyanUSize argc;
     /**
-     * @brief   Minimum # of accepted unnamed / anonymous arguments.
+     * Minimum # of accepted unnamed / anonymous arguments.
      */
     ZyanUSize min_unnamed_args;
     /**
-     * @brief   Maximum # of accepted unnamed / anonymous arguments.
+     * Maximum # of accepted unnamed / anonymous arguments.
      */
     ZyanUSize max_unnamed_args;
     /**
-     * @brief   Argument definition array, or `ZYAN_NULL`.
+     * Argument definition array, or `ZYAN_NULL`.
      *
      * Expects a pointer to an array of `ZyanArgParseDefinition` instances. The array is
      * terminated by setting the `.name` field of the last element to `ZYAN_NULL`. If no named
@@ -99,22 +99,22 @@ typedef struct ZyanArgParseConfig_
 } ZyanArgParseConfig;
 
 /**
- * @brief   Information about a parsed argument.
+ * Information about a parsed argument.
  */
 typedef struct ZyanArgParseArg_
 {
     /**
-     * @brief   Corresponding argument definition, or `ZYAN_NULL` for unnamed args.
+     * Corresponding argument definition, or `ZYAN_NULL` for unnamed args.
      *
      * This pointer is borrowed from the `cfg` pointer passed to `ZyanArgParse`.
      */
     const ZyanArgParseDefinition* def;
     /**
-     * @brief   Whether the argument has a value (is non-boolean).
+     * Whether the argument has a value (is non-boolean).
      */
     ZyanBool has_value;
     /**
-     * @brief   If `has_value == true`, then the argument value.
+     * If `has_value == true`, then the argument value.
      *
      * This is a view into the `argv` string array passed to `ZyanArgParse` via the `cfg` argument.
      */
@@ -128,7 +128,7 @@ typedef struct ZyanArgParseArg_
 #ifndef ZYAN_NO_LIBC
 
 /**
- * @brief  Parse arguments according to a `ZyanArgParseConfig` definition.
+ * Parse arguments according to a `ZyanArgParseConfig` definition.
  *
  * @param  cfg          Argument parser config to use.
  * @param  parsed       Receives the parsed output. Vector of `ZyanArgParseArg`. Ownership is
@@ -146,7 +146,7 @@ ZYCORE_EXPORT ZyanStatus ZyanArgParse(const ZyanArgParseConfig *cfg, ZyanVector*
 #endif
 
 /**
- * @brief  Parse arguments according to a `ZyanArgParseConfig` definition.
+ * Parse arguments according to a `ZyanArgParseConfig` definition.
  *
  * This version allows specification of a custom memory allocator and thus supports no-libc.
  *

--- a/include/Zycore/Bitset.h
+++ b/include/Zycore/Bitset.h
@@ -26,7 +26,7 @@
 
 /**
  * @file
- * @brief   Implements the bitset class.
+ * Implements the bitset class.
  */
 
 #ifndef ZYCORE_BITSET_H
@@ -47,7 +47,7 @@ extern "C" {
 /* ============================================================================================== */
 
 /**
- * @brief   Defines the `ZyanVector` struct.
+ * Defines the `ZyanVector` struct.
  *
  * All fields in this struct should be considered as "private". Any changes may lead to unexpected
  * behavior.
@@ -55,17 +55,17 @@ extern "C" {
 typedef struct ZyanBitset_
 {
     /**
-     * @brief   The bitset size.
+     * The bitset size.
      */
     ZyanUSize size;
     /**
-     * @brief   The bitset data.
+     * The bitset data.
      */
     ZyanVector bits;
 } ZyanBitset;
 
 /**
- * @brief   Defines the `ZyanBitsetByteOperation` function prototype.
+ * Defines the `ZyanBitsetByteOperation` function prototype.
  *
  * @param   v1  A pointer to the first byte. This value receives the result after performing the
  *              desired operation.
@@ -88,7 +88,7 @@ typedef ZyanStatus (*ZyanBitsetByteOperation)(ZyanU8* v1, const ZyanU8* v2);
 #ifndef ZYAN_NO_LIBC
 
 /**
- * @brief   Initializes the given `ZyanBitset` instance.
+ * Initializes the given `ZyanBitset` instance.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  * @param   count   The initial amount of bits.
@@ -103,8 +103,8 @@ ZYCORE_EXPORT ZYAN_REQUIRES_LIBC ZyanStatus ZyanBitsetInit(ZyanBitset* bitset, Z
 #endif // ZYAN_NO_LIBC
 
 /**
- * @brief   Initializes the given `ZyanBitset` instance and sets a custom `allocator` and memory
- *          allocation/deallocation parameters.
+ * Initializes the given `ZyanBitset` instance and sets a custom `allocator` and memory
+ * allocation/deallocation parameters.
  *
  * @param   bitset              A pointer to the `ZyanBitset` instance.
  * @param   count               The initial amount of bits.
@@ -121,8 +121,8 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetInitEx(ZyanBitset* bitset, ZyanUSize count,
     ZyanAllocator* allocator, float growth_factor, float shrink_threshold);
 
 /**
- * @brief   Initializes the given `ZyanBitset` instance and configures it to use a custom user
- *          defined buffer with a fixed size.
+ * Initializes the given `ZyanBitset` instance and configures it to use a custom user
+ * defined buffer with a fixed size.
  *
  * @param   bitset      A pointer to the `ZyanBitset` instance.
  * @param   count       The initial amount of bits.
@@ -135,7 +135,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetInitBuffer(ZyanBitset* bitset, ZyanUSize coun
     ZyanUSize capacity);
 
 /**
- * @brief   Destroys the given `ZyanBitset` instance.
+ * Destroys the given `ZyanBitset` instance.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  *
@@ -148,7 +148,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetDestroy(ZyanBitset* bitset);
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Performs a byte-wise `operation` for every byte in the given `ZyanBitset` instances.
+ * Performs a byte-wise `operation` for every byte in the given `ZyanBitset` instances.
  *
  * @param   destination A pointer to the `ZyanBitset` instance that is used as the first input and
  *                      as the destination.
@@ -164,7 +164,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetPerformByteOperation(ZyanBitset* destination,
     const ZyanBitset* source, ZyanBitsetByteOperation operation);
 
 /**
- * @brief   Performs a logical `AND` operation on the given `ZyanBitset` instances.
+ * Performs a logical `AND` operation on the given `ZyanBitset` instances.
  *
  * @param   destination A pointer to the `ZyanBitset` instance that is used as the first input and
  *                      as the destination.
@@ -178,7 +178,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetPerformByteOperation(ZyanBitset* destination,
 ZYCORE_EXPORT ZyanStatus ZyanBitsetAND(ZyanBitset* destination, const ZyanBitset* source);
 
 /**
- * @brief   Performs a logical `OR`  operation on the given `ZyanBitset` instances.
+ * Performs a logical `OR`  operation on the given `ZyanBitset` instances.
  *
  * @param   destination A pointer to the `ZyanBitset` instance that is used as the first input and
  *                      as the destination.
@@ -192,7 +192,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetAND(ZyanBitset* destination, const ZyanBitset
 ZYCORE_EXPORT ZyanStatus ZyanBitsetOR (ZyanBitset* destination, const ZyanBitset* source);
 
 /**
- * @brief   Performs a logical `XOR` operation on the given `ZyanBitset` instances.
+ * Performs a logical `XOR` operation on the given `ZyanBitset` instances.
  *
  * @param   destination A pointer to the `ZyanBitset` instance that is used as the first input and
  *                      as the destination.
@@ -206,7 +206,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetOR (ZyanBitset* destination, const ZyanBitset
 ZYCORE_EXPORT ZyanStatus ZyanBitsetXOR(ZyanBitset* destination, const ZyanBitset* source);
 
 /**
- * @brief   Flips all bits of the given `ZyanBitset` instance.
+ * Flips all bits of the given `ZyanBitset` instance.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  *
@@ -219,7 +219,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetFlip(ZyanBitset* bitset);
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Sets the bit at `index` of the given `ZyanBitset` instance to `1`.
+ * Sets the bit at `index` of the given `ZyanBitset` instance to `1`.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  * @param   index   The bit index.
@@ -229,7 +229,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetFlip(ZyanBitset* bitset);
 ZYCORE_EXPORT ZyanStatus ZyanBitsetSet(ZyanBitset* bitset, ZyanUSize index);
 
 /**
- * @brief   Sets the bit at `index` of the given `ZyanBitset` instance to `0`.
+ * Sets the bit at `index` of the given `ZyanBitset` instance to `0`.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  * @param   index   The bit index.
@@ -239,7 +239,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetSet(ZyanBitset* bitset, ZyanUSize index);
 ZYCORE_EXPORT ZyanStatus ZyanBitsetReset(ZyanBitset* bitset, ZyanUSize index);
 
 /**
- * @brief   Sets the bit at `index` of the given `ZyanBitset` instance to the specified `value`.
+ * Sets the bit at `index` of the given `ZyanBitset` instance to the specified `value`.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  * @param   index   The bit index.
@@ -250,7 +250,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetReset(ZyanBitset* bitset, ZyanUSize index);
 ZYCORE_EXPORT ZyanStatus ZyanBitsetAssign(ZyanBitset* bitset, ZyanUSize index, ZyanBool value);
 
 /**
- * @brief   Toggles the bit at `index` of the given `ZyanBitset` instance.
+ * Toggles the bit at `index` of the given `ZyanBitset` instance.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  * @param   index   The bit index.
@@ -260,7 +260,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetAssign(ZyanBitset* bitset, ZyanUSize index, Z
 ZYCORE_EXPORT ZyanStatus ZyanBitsetToggle(ZyanBitset* bitset, ZyanUSize index);
 
 /**
- * @brief   Returns the value of the bit at `index`.
+ * Returns the value of the bit at `index`.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  * @param   index   The bit index.
@@ -271,7 +271,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetToggle(ZyanBitset* bitset, ZyanUSize index);
 ZYCORE_EXPORT ZyanStatus ZyanBitsetTest(ZyanBitset* bitset, ZyanUSize index);
 
 /**
- * @brief   Returns the value of the most significant bit.
+ * Returns the value of the most significant bit.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  *
@@ -281,7 +281,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetTest(ZyanBitset* bitset, ZyanUSize index);
 ZYCORE_EXPORT ZyanStatus ZyanBitsetTestMSB(ZyanBitset* bitset);
 
 /**
- * @brief   Returns the value of the least significant bit.
+ * Returns the value of the least significant bit.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  *
@@ -293,7 +293,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetTestLSB(ZyanBitset* bitset);
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Sets all bits of the given `ZyanBitset` instance to `1`.
+ * Sets all bits of the given `ZyanBitset` instance to `1`.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  *
@@ -302,7 +302,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetTestLSB(ZyanBitset* bitset);
 ZYCORE_EXPORT ZyanStatus ZyanBitsetSetAll(ZyanBitset* bitset);
 
 /**
- * @brief   Sets all bits of the given `ZyanBitset` instance to `0`.
+ * Sets all bits of the given `ZyanBitset` instance to `0`.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  *
@@ -315,7 +315,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetResetAll(ZyanBitset* bitset);
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Adds a new bit at the end of the bitset.
+ * Adds a new bit at the end of the bitset.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  * @param   value   The value of the new bit.
@@ -325,7 +325,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetResetAll(ZyanBitset* bitset);
 ZYCORE_EXPORT ZyanStatus ZyanBitsetPush(ZyanBitset* bitset, ZyanBool value);
 
 /**
- * @brief   Removes the last bit of the bitset.
+ * Removes the last bit of the bitset.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  *
@@ -334,7 +334,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetPush(ZyanBitset* bitset, ZyanBool value);
 ZYCORE_EXPORT ZyanStatus ZyanBitsetPop(ZyanBitset* bitset);
 
 /**
- * @brief   Deletes all bits of the given `ZyanBitset` instance.
+ * Deletes all bits of the given `ZyanBitset` instance.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  *
@@ -347,7 +347,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetClear(ZyanBitset* bitset);
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Changes the capacity of the given `ZyanBitset` instance.
+ * Changes the capacity of the given `ZyanBitset` instance.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  * @param   count   The new capacity (number of bits).
@@ -357,7 +357,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetClear(ZyanBitset* bitset);
 ZYCORE_EXPORT ZyanStatus ZyanBitsetReserve(ZyanBitset* bitset, ZyanUSize count);
 
 /**
- * @brief   Shrinks the capacity of the given bitset to match it's size.
+ * Shrinks the capacity of the given bitset to match it's size.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  *
@@ -370,7 +370,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetShrinkToFit(ZyanBitset* bitset);
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Returns the current size of the bitset in bits.
+ * Returns the current size of the bitset in bits.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  * @param   size    Receives the size of the bitset in bits.
@@ -380,7 +380,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetShrinkToFit(ZyanBitset* bitset);
 ZYCORE_EXPORT ZyanStatus ZyanBitsetGetSize(const ZyanBitset* bitset, ZyanUSize* size);
 
 /**
- * @brief   Returns the current capacity of the bitset in bits.
+ * Returns the current capacity of the bitset in bits.
  *
  * @param   bitset      A pointer to the `ZyanBitset` instance.
  * @param   capacity    Receives the size of the bitset in bits.
@@ -390,7 +390,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetGetSize(const ZyanBitset* bitset, ZyanUSize* 
 ZYCORE_EXPORT ZyanStatus ZyanBitsetGetCapacity(const ZyanBitset* bitset, ZyanUSize* capacity);
 
 /**
- * @brief   Returns the current size of the bitset in bytes.
+ * Returns the current size of the bitset in bytes.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  * @param   size    Receives the size of the bitset in bytes.
@@ -400,7 +400,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetGetCapacity(const ZyanBitset* bitset, ZyanUSi
 ZYCORE_EXPORT ZyanStatus ZyanBitsetGetSizeBytes(const ZyanBitset* bitset, ZyanUSize* size);
 
 /**
- * @brief   Returns the current capacity of the bitset in bytes.
+ * Returns the current capacity of the bitset in bytes.
  *
  * @param   bitset      A pointer to the `ZyanBitset` instance.
  * @param   capacity    Receives the size of the bitset in bytes.
@@ -412,7 +412,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetGetCapacityBytes(const ZyanBitset* bitset, Zy
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Returns the amount of bits set in the given bitset.
+ * Returns the amount of bits set in the given bitset.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  * @param   count   Receives the amount of bits set in the given bitset.
@@ -422,7 +422,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetGetCapacityBytes(const ZyanBitset* bitset, Zy
 ZYCORE_EXPORT ZyanStatus ZyanBitsetCount(const ZyanBitset* bitset, ZyanUSize* count);
 
 /**
- * @brief   Checks, if all bits of the given bitset are set.
+ * Checks, if all bits of the given bitset are set.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  *
@@ -432,7 +432,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetCount(const ZyanBitset* bitset, ZyanUSize* co
 ZYCORE_EXPORT ZyanStatus ZyanBitsetAll(const ZyanBitset* bitset);
 
 /**
- * @brief   Checks, if at least one bit of the given bitset is set.
+ * Checks, if at least one bit of the given bitset is set.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  *
@@ -442,7 +442,7 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetAll(const ZyanBitset* bitset);
 ZYCORE_EXPORT ZyanStatus ZyanBitsetAny(const ZyanBitset* bitset);
 
 /**
- * @brief   Checks, if none bits of the given bitset are set.
+ * Checks, if none bits of the given bitset are set.
  *
  * @param   bitset  A pointer to the `ZyanBitset` instance.
  *
@@ -454,22 +454,22 @@ ZYCORE_EXPORT ZyanStatus ZyanBitsetNone(const ZyanBitset* bitset);
 ///* ---------------------------------------------------------------------------------------------- */
 //
 ///**
-// * @brief   Returns a 32-bit unsigned integer representation of the data.
-// * 
+// * Returns a 32-bit unsigned integer representation of the data.
+// *
 // * @param   bitset  A pointer to the `ZyanBitset` instance.
 // * @param   value   Receives the 32-bit unsigned integer representation of the data.
-// * 
-// * @return  A zyan status code. 
+// *
+// * @return  A zyan status code.
 // */
 //ZYCORE_EXPORT ZyanStatus ZyanBitsetToU32(const ZyanBitset* bitset, ZyanU32* value);
 //
 ///**
-// * @brief   Returns a 64-bit unsigned integer representation of the data.
-// * 
+// * Returns a 64-bit unsigned integer representation of the data.
+// *
 // * @param   bitset  A pointer to the `ZyanBitset` instance.
 // * @param   value   Receives the 64-bit unsigned integer representation of the data.
-// * 
-// * @return  A zyan status code. 
+// *
+// * @return  A zyan status code.
 // */
 //ZYCORE_EXPORT ZyanStatus ZyanBitsetToU64(const ZyanBitset* bitset, ZyanU64* value);
 

--- a/include/Zycore/Comparison.h
+++ b/include/Zycore/Comparison.h
@@ -26,7 +26,7 @@
 
 /**
  * @file
- * @brief   Defines prototypes of general-purpose comparison functions.
+ * Defines prototypes of general-purpose comparison functions.
  */
 
 #ifndef ZYCORE_COMPARISON_H
@@ -44,7 +44,7 @@ extern "C" {
 /* ============================================================================================== */
 
 /**
- * @brief   Defines the `ZyanEqualityComparison` function prototype.
+ * Defines the `ZyanEqualityComparison` function prototype.
  *
  * @param   left    A pointer to the first element.
  * @param   right   A pointer to the second element.
@@ -55,7 +55,7 @@ extern "C" {
 typedef ZyanBool (*ZyanEqualityComparison)(const void* left, const void* right);
 
 /**
- * @brief   Defines the `ZyanComparison` function prototype.
+ * Defines the `ZyanComparison` function prototype.
  *
  * @param   left    A pointer to the first element.
  * @param   right   A pointer to the second element.
@@ -76,7 +76,7 @@ typedef ZyanI32 (*ZyanComparison)(const void* left, const void* right);
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Declares a generic equality comparison function for an integral datatype.
+ * Declares a generic equality comparison function for an integral datatype.
  *
  * @param   name    The name of the function.
  * @param   type    The name of the integral datatype.
@@ -91,8 +91,8 @@ typedef ZyanI32 (*ZyanComparison)(const void* left, const void* right);
     }
 
 /**
- * @brief   Declares a generic equality comparison function that compares a single integral
- *          datatype field of a struct.
+ * Declares a generic equality comparison function that compares a single integral
+ * datatype field of a struct.
  *
  * @param   name        The name of the function.
  * @param   type        The name of the integral datatype.
@@ -112,7 +112,7 @@ typedef ZyanI32 (*ZyanComparison)(const void* left, const void* right);
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Declares a generic comparison function for an integral datatype.
+ * Declares a generic comparison function for an integral datatype.
  *
  * @param   name    The name of the function.
  * @param   type    The name of the integral datatype.
@@ -135,8 +135,8 @@ typedef ZyanI32 (*ZyanComparison)(const void* left, const void* right);
     }
 
 /**
- * @brief   Declares a generic comparison function that compares a single integral datatype field
- *          of a struct.
+ * Declares a generic comparison function that compares a single integral datatype field
+ * of a struct.
  *
  * @param   name        The name of the function.
  * @param   type        The name of the integral datatype.
@@ -170,7 +170,7 @@ typedef ZyanI32 (*ZyanComparison)(const void* left, const void* right);
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Defines a default equality comparison function for pointer values.
+ * Defines a default equality comparison function for pointer values.
  *
  * @param   left    A pointer to the first value.
  * @param   right   A pointer to the second value.
@@ -181,7 +181,7 @@ typedef ZyanI32 (*ZyanComparison)(const void* left, const void* right);
 ZYAN_INLINE ZYAN_DECLARE_EQUALITY_COMPARISON(ZyanEqualsPointer, void* const)
 
 /**
- * @brief   Defines a default equality comparison function for `ZyanBool` values.
+ * Defines a default equality comparison function for `ZyanBool` values.
  *
  * @param   left    A pointer to the first value.
  * @param   right   A pointer to the second value.
@@ -192,7 +192,7 @@ ZYAN_INLINE ZYAN_DECLARE_EQUALITY_COMPARISON(ZyanEqualsPointer, void* const)
 ZYAN_INLINE ZYAN_DECLARE_EQUALITY_COMPARISON(ZyanEqualsBool, ZyanBool)
 
 /**
- * @brief   Defines a default equality comparison function for 8-bit numeric values.
+ * Defines a default equality comparison function for 8-bit numeric values.
  *
  * @param   left    A pointer to the first value.
  * @param   right   A pointer to the second value.
@@ -203,7 +203,7 @@ ZYAN_INLINE ZYAN_DECLARE_EQUALITY_COMPARISON(ZyanEqualsBool, ZyanBool)
 ZYAN_INLINE ZYAN_DECLARE_EQUALITY_COMPARISON(ZyanEqualsNumeric8, ZyanU8)
 
 /**
- * @brief   Defines a default equality comparison function for 16-bit numeric values.
+ * Defines a default equality comparison function for 16-bit numeric values.
  *
  * @param   left    A pointer to the first value.
  * @param   right   A pointer to the second value.
@@ -214,7 +214,7 @@ ZYAN_INLINE ZYAN_DECLARE_EQUALITY_COMPARISON(ZyanEqualsNumeric8, ZyanU8)
 ZYAN_INLINE ZYAN_DECLARE_EQUALITY_COMPARISON(ZyanEqualsNumeric16, ZyanU16)
 
 /**
- * @brief   Defines a default equality comparison function for 32-bit numeric values.
+ * Defines a default equality comparison function for 32-bit numeric values.
  *
  * @param   left    A pointer to the first value.
  * @param   right   A pointer to the second value.
@@ -225,7 +225,7 @@ ZYAN_INLINE ZYAN_DECLARE_EQUALITY_COMPARISON(ZyanEqualsNumeric16, ZyanU16)
 ZYAN_INLINE ZYAN_DECLARE_EQUALITY_COMPARISON(ZyanEqualsNumeric32, ZyanU32)
 
 /**
- * @brief   Defines a default equality comparison function for 64-bit numeric values.
+ * Defines a default equality comparison function for 64-bit numeric values.
  *
  * @param   left    A pointer to the first value.
  * @param   right   A pointer to the second value.
@@ -240,7 +240,7 @@ ZYAN_INLINE ZYAN_DECLARE_EQUALITY_COMPARISON(ZyanEqualsNumeric64, ZyanU64)
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Defines a default comparison function for pointer values.
+ * Defines a default comparison function for pointer values.
  *
  * @param   left    A pointer to the first value.
  * @param   right   A pointer to the second value.
@@ -251,7 +251,7 @@ ZYAN_INLINE ZYAN_DECLARE_EQUALITY_COMPARISON(ZyanEqualsNumeric64, ZyanU64)
 ZYAN_INLINE ZYAN_DECLARE_COMPARISON(ZyanComparePointer, void* const)
 
 /**
- * @brief   Defines a default comparison function for `ZyanBool` values.
+ * Defines a default comparison function for `ZyanBool` values.
  *
  * @param   left    A pointer to the first value.
  * @param   right   A pointer to the second value.
@@ -262,7 +262,7 @@ ZYAN_INLINE ZYAN_DECLARE_COMPARISON(ZyanComparePointer, void* const)
 ZYAN_INLINE ZYAN_DECLARE_COMPARISON(ZyanCompareBool, ZyanBool)
 
 /**
- * @brief   Defines a default comparison function for 8-bit numeric values.
+ * Defines a default comparison function for 8-bit numeric values.
  *
  * @param   left    A pointer to the first value.
  * @param   right   A pointer to the second value.
@@ -273,7 +273,7 @@ ZYAN_INLINE ZYAN_DECLARE_COMPARISON(ZyanCompareBool, ZyanBool)
 ZYAN_INLINE ZYAN_DECLARE_COMPARISON(ZyanCompareNumeric8, ZyanU8)
 
 /**
- * @brief   Defines a default comparison function for 16-bit numeric values.
+ * Defines a default comparison function for 16-bit numeric values.
  *
  * @param   left    A pointer to the first value.
  * @param   right   A pointer to the second value.
@@ -284,7 +284,7 @@ ZYAN_INLINE ZYAN_DECLARE_COMPARISON(ZyanCompareNumeric8, ZyanU8)
 ZYAN_INLINE ZYAN_DECLARE_COMPARISON(ZyanCompareNumeric16, ZyanU16)
 
 /**
- * @brief   Defines a default comparison function for 32-bit numeric values.
+ * Defines a default comparison function for 32-bit numeric values.
  *
  * @param   left    A pointer to the first value.
  * @param   right   A pointer to the second value.
@@ -295,7 +295,7 @@ ZYAN_INLINE ZYAN_DECLARE_COMPARISON(ZyanCompareNumeric16, ZyanU16)
 ZYAN_INLINE ZYAN_DECLARE_COMPARISON(ZyanCompareNumeric32, ZyanU32)
 
 /**
- * @brief   Defines a default comparison function for 64-bit numeric values.
+ * Defines a default comparison function for 64-bit numeric values.
  *
  * @param   left    A pointer to the first value.
  * @param   right   A pointer to the second value.

--- a/include/Zycore/Defines.h
+++ b/include/Zycore/Defines.h
@@ -26,7 +26,7 @@
 
 /**
  * @file
- * @brief   General helper and platform detection macros.
+ * General helper and platform detection macros.
  */
 
 #ifndef ZYCORE_DEFINES_H
@@ -37,21 +37,21 @@
 /* ============================================================================================== */
 
 /**
- * @brief   Concatenates two values using the stringify operator (`##`).
+ * Concatenates two values using the stringify operator (`##`).
  *
- * @brief   x   The first value.
- * @brief   y   The second value.
+ * @param   x   The first value.
+ * @param   y   The second value.
  *
  * @return  The combined string of the given values.
  */
 #define ZYAN_MACRO_CONCAT(x, y) x ## y
 
 /**
- * @brief   Concatenates two values using the stringify operator (`##`) and expands the value to
- *          be used in another macro.
+ * Concatenates two values using the stringify operator (`##`) and expands the value to
+ * be used in another macro.
  *
- * @brief   x   The first value.
- * @brief   y   The second value.
+ * @param   x   The first value.
+ * @param   y   The second value.
  *
  * @return  The combined string of the given values.
  */
@@ -172,7 +172,7 @@
 /* ============================================================================================== */
 
 /**
- * @brief   Runtime debug assersion.
+ * Runtime debug assersion.
  */
 #if defined(ZYAN_NO_LIBC)
 #   define ZYAN_ASSERT(condition) (void)(condition)
@@ -185,7 +185,7 @@
 #endif
 
 /**
- * @brief   Compiler-time assertion.
+ * Compiler-time assertion.
  */
 #if __STDC_VERSION__ >= 201112L && !defined(__cplusplus)
 #   define ZYAN_STATIC_ASSERT(x) _Static_assert(x, #x)
@@ -199,7 +199,7 @@
 #endif
 
 /**
- * @brief	Marks the current code path as unreachable.
+ * Marks the current code path as unreachable.
  */
 #if defined(ZYAN_RELEASE)
 #   if defined(ZYAN_CLANG) // GCC eagerly evals && RHS, we have to use nested ifs.
@@ -240,14 +240,14 @@
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Marks the specified parameter as unused.
+ * Marks the specified parameter as unused.
  *
  * @param   x   The name of the unused parameter.
  */
 #define ZYAN_UNUSED(x) (void)(x)
 
 /**
- * @brief   Intentional fallthrough.
+ * Intentional fallthrough.
  */
 #if defined(ZYAN_GCC) && __GNUC__ >= 7
 #   define ZYAN_FALLTHROUGH __attribute__((fallthrough))
@@ -256,19 +256,19 @@
 #endif
 
 /**
- * @brief   Declares a bitfield.
+ * Declares a bitfield.
  *
  * @param   x   The size (in bits) of the bitfield.
  */
 #define ZYAN_BITFIELD(x) : x
 
 /**
- * @brief   Marks functions that require libc (cannot be used with `ZYAN_NO_LIBC`).
+ * Marks functions that require libc (cannot be used with `ZYAN_NO_LIBC`).
  */
 #define ZYAN_REQUIRES_LIBC
 
 /**
- * @brief   Decorator for `printf`-style functions.
+ * Decorator for `printf`-style functions.
  *
  * @param   format_index    The 1-based index of the format string parameter.
  * @param   first_to_check  The 1-based index of the format arguments parameter.
@@ -284,7 +284,7 @@
 #endif
 
 /**
- * @brief   Decorator for `wprintf`-style functions.
+ * Decorator for `wprintf`-style functions.
  *
  * @param   format_index    The 1-based index of the format string parameter.
  * @param   first_to_check  The 1-based index of the format arguments parameter.
@@ -301,7 +301,7 @@
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Returns the length (number of elements) of an array.
+ * Returns the length (number of elements) of an array.
  *
  * @param   a   The name of the array.
  *
@@ -314,7 +314,7 @@
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Returns the smaller value of `a` or `b`.
+ * Returns the smaller value of `a` or `b`.
  *
  * @param   a   The first value.
  * @param   b   The second value.
@@ -324,7 +324,7 @@
 #define ZYAN_MIN(a, b) (((a) < (b)) ? (a) : (b))
 
 /**
- * @brief   Returns the bigger value of `a` or `b`.
+ * Returns the bigger value of `a` or `b`.
  *
  * @param   a   The first value.
  * @param   b   The second value.
@@ -334,7 +334,7 @@
 #define ZYAN_MAX(a, b) (((a) > (b)) ? (a) : (b))
 
 /**
- * @brief   Returns the absolute value of `a`.
+ * Returns the absolute value of `a`.
  *
  * @param   a   The value.
  *
@@ -343,7 +343,7 @@
 #define ZYAN_ABS(a) (((a) < 0) ? -(a) : (a))
 
 /**
- * @brief   Checks, if the given value is a power of 2.
+ * Checks, if the given value is a power of 2.
  *
  * @param   x   The value.
  *
@@ -354,14 +354,14 @@
 #define ZYAN_IS_POWER_OF_2(x) (((x) & ((x) - 1)) == 0)
 
 /**
- * @brief   Checks, if the given value is properly aligned.
+ * Checks, if the given value is properly aligned.
  *
  * Note that this macro only works for powers of 2.
  */
 #define ZYAN_IS_ALIGNED_TO(x, align) (((x) & ((align) - 1)) == 0)
 
 /**
- * @brief   Aligns the value to the nearest given alignment boundary (by rounding it up).
+ * Aligns the value to the nearest given alignment boundary (by rounding it up).
  *
  * @param   x       The value.
  * @param   align   The desired alignment.
@@ -373,7 +373,7 @@
 #define ZYAN_ALIGN_UP(x, align) (((x) + (align) - 1) & ~((align) - 1))
 
 /**
- * @brief   Aligns the value to the nearest given alignment boundary (by rounding it down).
+ * Aligns the value to the nearest given alignment boundary (by rounding it down).
  *
  * @param   x       The value.
  * @param   align   The desired alignment.
@@ -389,7 +389,7 @@
 /* ---------------------------------------------------------------------------------------------- */
 
 /*
- * @brief   Checks, if the bit at index `b` is required to present the ordinal value `n`.
+ * Checks, if the bit at index `b` is required to present the ordinal value `n`.
  *
  * @param   n   The ordinal value.
  * @param   b   The bit index.
@@ -402,7 +402,7 @@
 #define ZYAN_NEEDS_BIT(n, b) (((unsigned long)(n) >> (b)) > 0)
 
 /*
- * @brief   Returns the number of bits required to represent the ordinal value `n`.
+ * Returns the number of bits required to represent the ordinal value `n`.
  *
  * @param   n   The ordinal value.
  *

--- a/include/Zycore/Format.h
+++ b/include/Zycore/Format.h
@@ -26,7 +26,7 @@
 
 /**
  * @file
- * @brief   Provides helper functions for performant number to string conversion.
+ * Provides helper functions for performant number to string conversion.
  */
 
 #ifndef ZYCORE_FORMAT_H
@@ -50,7 +50,7 @@ extern "C" {
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Inserts formatted text in the destination string at the given `index`.
+ * Inserts formatted text in the destination string at the given `index`.
  *
  * @param   string  The destination string.
  * @param   index   The insert index.
@@ -69,8 +69,8 @@ ZYCORE_EXPORT ZyanStatus ZyanStringInsertFormat(ZyanString* string, ZyanUSize in
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Formats the given unsigned ordinal `value` to its decimal text-representation and
- *          inserts it to the `string`.
+ * Formats the given unsigned ordinal `value` to its decimal text-representation and
+ * inserts it to the `string`.
  *
  * @param   string          A pointer to the `ZyanString` instance.
  * @param   index           The insert index.
@@ -87,8 +87,8 @@ ZYCORE_EXPORT ZyanStatus ZyanStringInsertDecU(ZyanString* string, ZyanUSize inde
     ZyanU8 padding_length);
 
 /**
- * @brief   Formats the given signed ordinal `value` to its decimal text-representation and
- *          inserts it to the `string`.
+ * Formats the given signed ordinal `value` to its decimal text-representation and
+ * inserts it to the `string`.
  *
  * @param   string          A pointer to the `ZyanString` instance.
  * @param   index           The insert index.
@@ -107,8 +107,8 @@ ZYCORE_EXPORT ZyanStatus ZyanStringInsertDecS(ZyanString* string, ZyanUSize inde
     ZyanU8 padding_length, ZyanBool force_sign, const ZyanString* prefix);
 
 /**
- * @brief   Formats the given unsigned ordinal `value` to its hexadecimal text-representation and
- *          inserts it to the `string`.
+ * Formats the given unsigned ordinal `value` to its hexadecimal text-representation and
+ * inserts it to the `string`.
  *
  * @param   string          A pointer to the `ZyanString` instance.
  * @param   index           The insert index.
@@ -127,8 +127,8 @@ ZYCORE_EXPORT ZyanStatus ZyanStringInsertHexU(ZyanString* string, ZyanUSize inde
     ZyanU8 padding_length, ZyanBool uppercase);
 
 /**
- * @brief   Formats the given signed ordinal `value` to its hexadecimal text-representation and
- *          inserts it to the `string`.
+ * Formats the given signed ordinal `value` to its hexadecimal text-representation and
+ * inserts it to the `string`.
  *
  * @param   string          A pointer to the `ZyanString` instance.
  * @param   index           The insert index.
@@ -155,7 +155,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringInsertHexS(ZyanString* string, ZyanUSize inde
 #ifndef ZYAN_NO_LIBC
 
 /**
- * @brief   Appends formatted text to the destination string.
+ * Appends formatted text to the destination string.
  *
  * @param   string  The destination string.
  * @param   format  The format string.
@@ -175,8 +175,8 @@ ZYCORE_EXPORT ZYAN_REQUIRES_LIBC ZyanStatus ZyanStringAppendFormat(
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Formats the given unsigned ordinal `value` to its decimal text-representation and
- *          appends it to the `string`.
+ * Formats the given unsigned ordinal `value` to its decimal text-representation and
+ * appends it to the `string`.
  *
  * @param   string          A pointer to the `ZyanString` instance.
  * @param   value           The value.
@@ -192,8 +192,8 @@ ZYCORE_EXPORT ZyanStatus ZyanStringAppendDecU(ZyanString* string, ZyanU64 value,
     ZyanU8 padding_length);
 
 /**
- * @brief   Formats the given signed ordinal `value` to its decimal text-representation and
- *          appends it to the `string`.
+ * Formats the given signed ordinal `value` to its decimal text-representation and
+ * appends it to the `string`.
  *
  * @param   string          A pointer to the `ZyanString` instance.
  * @param   value           The value.
@@ -211,8 +211,8 @@ ZYCORE_EXPORT ZyanStatus ZyanStringAppendDecS(ZyanString* string, ZyanI64 value,
     ZyanU8 padding_length, ZyanBool force_sign, const ZyanStringView* prefix);
 
 /**
- * @brief   Formats the given unsigned ordinal `value` to its hexadecimal text-representation and
- *          appends it to the `string`.
+ * Formats the given unsigned ordinal `value` to its hexadecimal text-representation and
+ * appends it to the `string`.
  *
  * @param   string          A pointer to the `ZyanString` instance.
  * @param   value           The value.
@@ -230,8 +230,8 @@ ZYCORE_EXPORT ZyanStatus ZyanStringAppendHexU(ZyanString* string, ZyanU64 value,
     ZyanU8 padding_length, ZyanBool uppercase);
 
 /**
- * @brief   Formats the given signed ordinal `value` to its hexadecimal text-representation and
- *          appends it to the `string`.
+ * Formats the given signed ordinal `value` to its hexadecimal text-representation and
+ * appends it to the `string`.
  *
  * @param   string          A pointer to the `ZyanString` instance.
  * @param   value           The value.

--- a/include/Zycore/LibC.h
+++ b/include/Zycore/LibC.h
@@ -26,7 +26,7 @@
 
 /**
  * @file
- * @brief   Provides a simple LibC abstraction and fallback routines.
+ * Provides a simple LibC abstraction and fallback routines.
  */
 
 #ifndef ZYCORE_LIBC_H
@@ -58,7 +58,7 @@
 #include <stdarg.h>
 
 /**
- * @brief   Defines the `ZyanVAList` datatype.
+ * Defines the `ZyanVAList` datatype.
  */
 typedef va_list ZyanVAList;
 
@@ -84,7 +84,7 @@ typedef va_list ZyanVAList;
 #define ZYAN_VSNPRINTF  vsnprintf
 
 /**
- * @brief   Defines the `ZyanFile` datatype.
+ * Defines the `ZyanFile` datatype.
  */
 typedef FILE ZyanFile;
 
@@ -153,7 +153,7 @@ typedef FILE ZyanFile;
 #if defined(ZYAN_MSVC) || defined(ZYAN_ICC)
 
 /**
- * @brief   Defines the `ZyanVAList` datatype.
+ * Defines the `ZyanVAList` datatype.
  */
 typedef char* ZyanVAList;
 
@@ -165,7 +165,7 @@ typedef char* ZyanVAList;
 #elif defined(ZYAN_GNUC)
 
 /**
- * @brief   Defines the `ZyanVAList` datatype.
+ * Defines the `ZyanVAList` datatype.
  */
 typedef __builtin_va_list  ZyanVAList;
 

--- a/include/Zycore/List.h
+++ b/include/Zycore/List.h
@@ -26,7 +26,7 @@
 
 /**
  * @file
- * @brief   Implements a doubly linked list.
+ * Implements a doubly linked list.
  */
 
 #ifndef ZYCORE_LIST_H
@@ -47,7 +47,7 @@ extern "C" {
 /* ============================================================================================== */
 
 /**
- * @brief   Defines the `ZyanListNode` struct.
+ * Defines the `ZyanListNode` struct.
  *
  * All fields in this struct should be considered as "private". Any changes may lead to unexpected
  * behavior.
@@ -55,17 +55,17 @@ extern "C" {
 typedef struct ZyanListNode_
 {
     /**
-     * @brief   A pointer to the previous list node.
+     * A pointer to the previous list node.
      */
     struct ZyanListNode_* prev;
     /**
-     * @brief   A pointer to the next list node.
+     * A pointer to the next list node.
      */
     struct ZyanListNode_* next;
 } ZyanListNode;
 
 /**
- * @brief   Defines the `ZyanList` struct.
+ * Defines the `ZyanList` struct.
  *
  * All fields in this struct should be considered as "private". Any changes may lead to unexpected
  * behavior.
@@ -73,53 +73,53 @@ typedef struct ZyanListNode_
 typedef struct ZyanList_
 {
     /**
-     * @brief   The memory allocator.
+     * The memory allocator.
      */
     ZyanAllocator* allocator;
     /**
-     * @brief   The current number of elements in the list.
+     * The current number of elements in the list.
      */
     ZyanUSize size;
     /**
-     * @brief   The size of a single element in bytes.
+     * The size of a single element in bytes.
      */
     ZyanUSize element_size;
     /**
-     * @brief   The element destructor callback.   
+     * The element destructor callback.
      */
     ZyanMemberProcedure destructor;
     /**
-     * @brief   The head node.
+     * The head node.
      */
     ZyanListNode* head;
     /**
-     * @brief   The tail node.
+     * The tail node.
      */
     ZyanListNode* tail;
     /**
-     * @brief   The data buffer. 
-     * 
-     * Only used for instances created by `ZyanListInitCustomBuffer`.  
+     * The data buffer.
+     *
+     * Only used for instances created by `ZyanListInitCustomBuffer`.
      */
     void* buffer;
     /**
-     * @brief   The data buffer capacity (number of bytes). 
-     * 
+     * The data buffer capacity (number of bytes).
+     *
      * Only used for instances created by `ZyanListInitCustomBuffer`.
      */
     ZyanUSize capacity;
     /**
-     * @brief   The first unused node. 
-     * 
+     * The first unused node.
+     *
      * When removing a node, the first-unused value is updated to point at the removed node and the
      * next node of the removed node will be updated to point at the old first-unused node.
-     * 
+     *
      * When appending the memory of the first unused-node is recycled to store the new node. The
      * value of the first-unused node is then updated to point at the reused nodes next node.
-     * 
+     *
      * If the first-unused value is `ZYAN_NULL`, any new node will be "allocated" behind the tail
      * node (if there is enough space left in the fixed size buffer).
-     * 
+     *
      * Only used for instances created by `ZyanListInitCustomBuffer`.
      */
     ZyanListNode* first_unused;
@@ -134,7 +134,7 @@ typedef struct ZyanList_
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Defines an uninitialized `ZyanList` instance.
+ * Defines an uninitialized `ZyanList` instance.
  */
 #define ZYAN_LIST_INITIALIZER \
     { \
@@ -154,7 +154,7 @@ typedef struct ZyanList_
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Returns the data value of the given `node`.
+ * Returns the data value of the given `node`.
  *
  * @param   type    The desired value type.
  * @param   node    A pointer to the `ZyanListNode` struct.
@@ -184,7 +184,7 @@ typedef struct ZyanList_
 #ifndef ZYAN_NO_LIBC
 
 /**
- * @brief   Initializes the given `ZyanList` instance.
+ * Initializes the given `ZyanList` instance.
  *
  * @param   list            A pointer to the `ZyanList` instance.
  * @param   element_size    The size of a single element in bytes.
@@ -203,7 +203,7 @@ ZYCORE_EXPORT ZYAN_REQUIRES_LIBC ZyanStatus ZyanListInit(ZyanList* list, ZyanUSi
 #endif // ZYAN_NO_LIBC
 
 /**
- * @brief   Initializes the given `ZyanList` instance and sets a custom `allocator`.
+ * Initializes the given `ZyanList` instance and sets a custom `allocator`.
  *
  * @param   list            A pointer to the `ZyanList` instance.
  * @param   element_size    The size of a single element in bytes.
@@ -219,15 +219,15 @@ ZYCORE_EXPORT ZyanStatus ZyanListInitEx(ZyanList* list, ZyanUSize element_size,
     ZyanMemberProcedure destructor, ZyanAllocator* allocator);
 
 /**
- * @brief   Initializes the given `ZyanList` instance and configures it to use a custom user
- *          defined buffer with a fixed size.
+ * Initializes the given `ZyanList` instance and configures it to use a custom user
+ * defined buffer with a fixed size.
  *
  * @param   list            A pointer to the `ZyanList` instance.
  * @param   element_size    The size of a single element in bytes.
  * @param   destructor      A destructor callback that is invoked every time an item is deleted, or
  *                          `ZYAN_NULL` if not needed.
  * @param   buffer          A pointer to the buffer that is used as storage for the elements.
- * @param   capacity        The maximum capacity (number of bytes) of the buffer including the 
+ * @param   capacity        The maximum capacity (number of bytes) of the buffer including the
  *                          space required for the list-nodes.
  *
  * @return  A zyan status code.
@@ -241,7 +241,7 @@ ZYCORE_EXPORT ZyanStatus ZyanListInitCustomBuffer(ZyanList* list, ZyanUSize elem
     ZyanMemberProcedure destructor, void* buffer, ZyanUSize capacity);
 
 /**
- * @brief   Destroys the given `ZyanList` instance.
+ * Destroys the given `ZyanList` instance.
  *
  * @param   list    A pointer to the `ZyanList` instance.
  *
@@ -256,7 +256,7 @@ ZYCORE_EXPORT ZyanStatus ZyanListDestroy(ZyanList* list);
 #ifndef ZYAN_NO_LIBC
 
 /**
- * @brief   Initializes a new `ZyanList` instance by duplicating an existing list.
+ * Initializes a new `ZyanList` instance by duplicating an existing list.
  *
  * @param   destination A pointer to the (uninitialized) destination `ZyanList` instance.
  * @param   source      A pointer to the source list.
@@ -273,8 +273,8 @@ ZYCORE_EXPORT ZYAN_REQUIRES_LIBC ZyanStatus ZyanListDuplicate(ZyanList* destinat
 #endif // ZYAN_NO_LIBC
 
 /**
- * @brief   Initializes a new `ZyanList` instance by duplicating an existing list and sets a
- *          custom `allocator`.
+ * Initializes a new `ZyanList` instance by duplicating an existing list and sets a
+ * custom `allocator`.
  *
  * @param   destination A pointer to the (uninitialized) destination `ZyanList` instance.
  * @param   source      A pointer to the source list.
@@ -288,20 +288,20 @@ ZYCORE_EXPORT ZyanStatus ZyanListDuplicateEx(ZyanList* destination, const ZyanLi
     ZyanAllocator* allocator);
 
 /**
- * @brief   Initializes a new `ZyanList` instance by duplicating an existing list and
- *          configures it to use a custom user defined buffer with a fixed size.
+ * Initializes a new `ZyanList` instance by duplicating an existing list and
+ * configures it to use a custom user defined buffer with a fixed size.
  *
  * @param   destination A pointer to the (uninitialized) destination `ZyanList` instance.
  * @param   source      A pointer to the source list.
  * @param   buffer      A pointer to the buffer that is used as storage for the elements.
- * @param   capacity    The maximum capacity (number of bytes) of the buffer including the 
+ * @param   capacity    The maximum capacity (number of bytes) of the buffer including the
  *                      space required for the list-nodes.
 
  *                      This function will fail, if the capacity of the buffer is not sufficient
  *                      to store all elements of the source list.
  *
  * @return  A zyan status code.
- * 
+ *
  * The buffer capacity required to store `n` elements of type `T` is be calculated by:
  * `size = n * sizeof(ZyanListNode) + n * sizeof(T)`
  *
@@ -315,46 +315,46 @@ ZYCORE_EXPORT ZyanStatus ZyanListDuplicateCustomBuffer(ZyanList* destination,
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Returns a pointer to the first `ZyanListNode` struct of the given list.
- * 
+ * Returns a pointer to the first `ZyanListNode` struct of the given list.
+ *
  * @param   list    A pointer to the `ZyanList` instance.
  * @param   node    Receives a pointer to the first `ZyanListNode` struct of the list.
- * 
- * @return  A zyan status code.   
+ *
+ * @return  A zyan status code.
  */
 ZYCORE_EXPORT ZyanStatus ZyanListGetHeadNode(const ZyanList* list, const ZyanListNode** node);
 
 /**
- * @brief   Returns a pointer to the last `ZyanListNode` struct of the given list.
- * 
+ * Returns a pointer to the last `ZyanListNode` struct of the given list.
+ *
  * @param   list    A pointer to the `ZyanList` instance.
  * @param   node    Receives a pointer to the last `ZyanListNode` struct of the list.
- * 
- * @return  A zyan status code.   
+ *
+ * @return  A zyan status code.
  */
 ZYCORE_EXPORT ZyanStatus ZyanListGetTailNode(const ZyanList* list, const ZyanListNode** node);
 
 /**
- * @brief   Receives a pointer to the previous `ZyanListNode` struct linked to the passed one.
- * 
- * @param   node    Receives a pointer to the previous `ZyanListNode` struct linked to the passed 
+ * Receives a pointer to the previous `ZyanListNode` struct linked to the passed one.
+ *
+ * @param   node    Receives a pointer to the previous `ZyanListNode` struct linked to the passed
  *                  one.
- * 
+ *
  * @return  A zyan status code.
  */
 ZYCORE_EXPORT ZyanStatus ZyanListGetPrevNode(const ZyanListNode** node);
 
 /**
- * @brief   Receives a pointer to the next `ZyanListNode` struct linked to the passed one.
- * 
+ * Receives a pointer to the next `ZyanListNode` struct linked to the passed one.
+ *
  * @param   node    Receives a pointer to the next `ZyanListNode` struct linked to the passed one.
- * 
+ *
  * @return  A zyan status code.
  */
 ZYCORE_EXPORT ZyanStatus ZyanListGetNextNode(const ZyanListNode** node);
 
 /**
- * @brief   Returns a constant pointer to the data of the given `node`.
+ * Returns a constant pointer to the data of the given `node`.
  *
  * @param   node    A pointer to the `ZyanListNode` struct.
  *
@@ -366,7 +366,7 @@ ZYCORE_EXPORT ZyanStatus ZyanListGetNextNode(const ZyanListNode** node);
 ZYCORE_EXPORT const void* ZyanListGetNodeData(const ZyanListNode* node);
 
 /**
- * @brief   Returns a constant pointer to the data of the given `node`..
+ * Returns a constant pointer to the data of the given `node`..
  *
  * @param   node    A pointer to the `ZyanListNode` struct.
  * @param   value   Receives a constant pointer to the data of the given `node`.
@@ -378,25 +378,25 @@ ZYCORE_EXPORT const void* ZyanListGetNodeData(const ZyanListNode* node);
 ZYCORE_EXPORT ZyanStatus ZyanListGetNodeDataEx(const ZyanListNode* node, const void** value);
 
 /**
- * @brief   Returns a mutable pointer to the data of the given `node`.
+ * Returns a mutable pointer to the data of the given `node`.
  *
  * @param   node    A pointer to the `ZyanListNode` struct.
  *
  * @return  A mutable pointer to the the data of the given `node` or `ZYAN_NULL`, if an error
  *          occured.
  *
- * Take a look at `ZyanListGetPointerMutableEx` instead, if you need a function that returns a  
+ * Take a look at `ZyanListGetPointerMutableEx` instead, if you need a function that returns a
  * zyan status code.
  */
 ZYCORE_EXPORT void* ZyanListGetNodeDataMutable(const ZyanListNode* node);
 
 /**
- * @brief   Returns a mutable pointer to the data of the given `node`..
+ * Returns a mutable pointer to the data of the given `node`..
  *
  * @param   node    A pointer to the `ZyanListNode` struct.
  * @param   value   Receives a mutable pointer to the data of the given `node`.
  *
- * Take a look at `ZyanListGetNodeDataMutable`, if you need a function that directly returns a 
+ * Take a look at `ZyanListGetNodeDataMutable`, if you need a function that directly returns a
  * pointer.
  *
  * @return  A zyan status code.
@@ -404,7 +404,7 @@ ZYCORE_EXPORT void* ZyanListGetNodeDataMutable(const ZyanListNode* node);
 ZYCORE_EXPORT ZyanStatus ZyanListGetNodeDataMutableEx(const ZyanListNode* node, void** value);
 
 /**
- * @brief   Assigns a new data value to the given `node`.
+ * Assigns a new data value to the given `node`.
  *
  * @param   list    A pointer to the `ZyanList` instance.
  * @param   node    A pointer to the `ZyanListNode` struct.
@@ -412,7 +412,7 @@ ZYCORE_EXPORT ZyanStatus ZyanListGetNodeDataMutableEx(const ZyanListNode* node, 
  *
  * @return  A zyan status code.
  */
-ZYCORE_EXPORT ZyanStatus ZyanListSetNodeData(const ZyanList* list, const ZyanListNode* node, 
+ZYCORE_EXPORT ZyanStatus ZyanListSetNodeData(const ZyanList* list, const ZyanListNode* node,
     const void* value);
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -420,7 +420,7 @@ ZYCORE_EXPORT ZyanStatus ZyanListSetNodeData(const ZyanList* list, const ZyanLis
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Adds a new `item` to the end of the list.
+ * Adds a new `item` to the end of the list.
  *
  * @param   list    A pointer to the `ZyanList` instance.
  * @param   item    A pointer to the item to add.
@@ -430,7 +430,7 @@ ZYCORE_EXPORT ZyanStatus ZyanListSetNodeData(const ZyanList* list, const ZyanLis
 ZYCORE_EXPORT ZyanStatus ZyanListPushBack(ZyanList* list, const void* item);
 
 /**
- * @brief   Adds a new `item` to the beginning of the list.
+ * Adds a new `item` to the beginning of the list.
  *
  * @param   list    A pointer to the `ZyanList` instance.
  * @param   item    A pointer to the item to add.
@@ -440,7 +440,7 @@ ZYCORE_EXPORT ZyanStatus ZyanListPushBack(ZyanList* list, const void* item);
 ZYCORE_EXPORT ZyanStatus ZyanListPushFront(ZyanList* list, const void* item);
 
 /**
- * @brief   Constructs an `item` in-place at the end of the list.
+ * Constructs an `item` in-place at the end of the list.
  *
  * @param   list        A pointer to the `ZyanList` instance.
  * @param   item        Receives a pointer to the new item.
@@ -453,7 +453,7 @@ ZYCORE_EXPORT ZyanStatus ZyanListEmplaceBack(ZyanList* list, void** item,
     ZyanMemberFunction constructor);
 
 /**
- * @brief   Constructs an `item` in-place at the beginning of the list.
+ * Constructs an `item` in-place at the beginning of the list.
  *
  * @param   list        A pointer to the `ZyanList` instance.
  * @param   item        Receives a pointer to the new item.
@@ -470,7 +470,7 @@ ZYCORE_EXPORT ZyanStatus ZyanListEmplaceFront(ZyanList* list, void** item,
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Removes the last element of the list.
+ * Removes the last element of the list.
  *
  * @param   list    A pointer to the `ZyanList` instance.
  *
@@ -479,7 +479,7 @@ ZYCORE_EXPORT ZyanStatus ZyanListEmplaceFront(ZyanList* list, void** item,
 ZYCORE_EXPORT ZyanStatus ZyanListPopBack(ZyanList* list);
 
 /**
- * @brief   Removes the firstelement of the list.
+ * Removes the firstelement of the list.
  *
  * @param   list    A pointer to the `ZyanList` instance.
  *
@@ -488,7 +488,7 @@ ZYCORE_EXPORT ZyanStatus ZyanListPopBack(ZyanList* list);
 ZYCORE_EXPORT ZyanStatus ZyanListPopFront(ZyanList* list);
 
 /**
- * @brief   Removes the given `node` from the list.
+ * Removes the given `node` from the list.
  *
  * @param   list    A pointer to the `ZyanList` instance.
  * @param   node    A pointer to the `ZyanListNode` struct.
@@ -498,7 +498,7 @@ ZYCORE_EXPORT ZyanStatus ZyanListPopFront(ZyanList* list);
 ZYCORE_EXPORT ZyanStatus ZyanListRemove(ZyanList* list, const ZyanListNode* node);
 
 /**
- * @brief   Removes multiple nodes from the list.
+ * Removes multiple nodes from the list.
  *
  * @param   list    A pointer to the `ZyanList` instance.
  * @param   first   A pointer to the first node.
@@ -506,11 +506,11 @@ ZYCORE_EXPORT ZyanStatus ZyanListRemove(ZyanList* list, const ZyanListNode* node
  *
  * @return  A zyan status code.
  */
-ZYCORE_EXPORT ZyanStatus ZyanListRemoveRange(ZyanList* list, const ZyanListNode* first, 
+ZYCORE_EXPORT ZyanStatus ZyanListRemoveRange(ZyanList* list, const ZyanListNode* first,
     const ZyanListNode* last);
 
 /**
- * @brief   Erases all elements of the list.
+ * Erases all elements of the list.
  *
  * @param   list    A pointer to the `ZyanList` instance.
  *
@@ -529,7 +529,7 @@ ZYCORE_EXPORT ZyanStatus ZyanListClear(ZyanList* list);
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Resizes the given `ZyanList` instance.
+ * Resizes the given `ZyanList` instance.
  *
  * @param   list    A pointer to the `ZyanList` instance.
  * @param   size    The new size of the list.
@@ -539,7 +539,7 @@ ZYCORE_EXPORT ZyanStatus ZyanListClear(ZyanList* list);
 ZYCORE_EXPORT ZyanStatus ZyanListResize(ZyanList* list, ZyanUSize size);
 
 /**
- * @brief   Resizes the given `ZyanList` instance.
+ * Resizes the given `ZyanList` instance.
  *
  * @param   list        A pointer to the `ZyanList` instance.
  * @param   size        The new size of the list.
@@ -554,7 +554,7 @@ ZYCORE_EXPORT ZyanStatus ZyanListResizeEx(ZyanList* list, ZyanUSize size, const 
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Returns the current size of the list.
+ * Returns the current size of the list.
  *
  * @param   list    A pointer to the `ZyanList` instance.
  * @param   size    Receives the size of the list.

--- a/include/Zycore/Object.h
+++ b/include/Zycore/Object.h
@@ -26,7 +26,7 @@
 
 /**
  * @file
- * @brief   Defines some generic object-related datatypes.
+ * Defines some generic object-related datatypes.
  */
 
 #ifndef ZYCORE_OBJECT_H
@@ -44,21 +44,21 @@ extern "C" {
 /* ============================================================================================== */
 
 /**
- * @brief   Defines the `ZyanMemberProcedure` function prototype.
+ * Defines the `ZyanMemberProcedure` function prototype.
  *
  * @param   object  A pointer to the object.
  */
 typedef void (*ZyanMemberProcedure)(void* object);
 
 /**
- * @brief   Defines the `ZyanConstMemberProcedure` function prototype.
+ * Defines the `ZyanConstMemberProcedure` function prototype.
  *
  * @param   object  A pointer to the object.
  */
 typedef void (*ZyanConstMemberProcedure)(const void* object);
 
 /**
- * @brief   Defines the `ZyanMemberFunction` function prototype.
+ * Defines the `ZyanMemberFunction` function prototype.
  *
  * @param   object  A pointer to the object.
  *
@@ -67,7 +67,7 @@ typedef void (*ZyanConstMemberProcedure)(const void* object);
 typedef ZyanStatus (*ZyanMemberFunction)(void* object);
 
 /**
- * @brief   Defines the `ZyanConstMemberFunction` function prototype.
+ * Defines the `ZyanConstMemberFunction` function prototype.
  *
  * @param   object  A pointer to the object.
  *

--- a/include/Zycore/Status.h
+++ b/include/Zycore/Status.h
@@ -26,7 +26,7 @@
 
 /**
  * @file
- * @brief   Status code definitions and check macros.
+ * Status code definitions and check macros.
  */
 
 #ifndef ZYCORE_STATUS_H
@@ -43,7 +43,7 @@ extern "C" {
 /* ============================================================================================== */
 
 /**
- * @brief   Defines the `ZyanStatus` data type.
+ * Defines the `ZyanStatus` data type.
  */
 typedef ZyanU32 ZyanStatus;
 
@@ -56,7 +56,7 @@ typedef ZyanU32 ZyanStatus;
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Defines a zyan status code.
+ * Defines a zyan status code.
  *
  * @param   error   `1`, if the status code signals an error or `0`, if not.
  * @param   module  The module id.
@@ -72,7 +72,7 @@ typedef ZyanU32 ZyanStatus;
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Checks if a zyan operation was successful.
+ * Checks if a zyan operation was successful.
  *
  * @param   status  The zyan status-code to check.
  *
@@ -82,7 +82,7 @@ typedef ZyanU32 ZyanStatus;
     (!((status) & 0x80000000))
 
 /**
- * @brief   Checks if a zyan operation failed.
+ * Checks if a zyan operation failed.
  *
  * @param   status  The zyan status-code to check.
  *
@@ -92,7 +92,7 @@ typedef ZyanU32 ZyanStatus;
     ((status) & 0x80000000)
 
 /**
- * @brief   Checks if a zyan operation was successful and returns with the status-code, if not.
+ * Checks if a zyan operation was successful and returns with the status-code, if not.
  *
  * @param   status  The zyan status-code to check.
  */
@@ -111,7 +111,7 @@ typedef ZyanU32 ZyanStatus;
 /* ---------------------------------------------------------------------------------------------- */
 
  /**
- * @brief   Returns the module id of a zyan status-code.
+ * Returns the module id of a zyan status-code.
  *
  * @param   status  The zyan status-code.
  *
@@ -121,7 +121,7 @@ typedef ZyanU32 ZyanStatus;
     (((status) >> 20) & 0x7FF)
 
  /**
- * @brief   Returns the code of a zyan status-code.
+ * Returns the code of a zyan status-code.
  *
  * @param   status  The zyan status-code.
  *
@@ -139,17 +139,17 @@ typedef ZyanU32 ZyanStatus;
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   The zycore generic module id.
+ * The zycore generic module id.
  */
 #define ZYAN_MODULE_ZYCORE      0x001
 
 /**
- * @brief   The zycore arg-parse submodule id.
+ * The zycore arg-parse submodule id.
  */
 #define ZYAN_MODULE_ARGPARSE    0x003
 
 /**
- * @brief   The base module id for user-defined status codes.
+ * The base module id for user-defined status codes.
  */
 #define ZYAN_MODULE_USER        0x3FF
 
@@ -158,86 +158,86 @@ typedef ZyanU32 ZyanStatus;
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   The operation completed successfully.
+ * The operation completed successfully.
  */
 #define ZYAN_STATUS_SUCCESS \
     ZYAN_MAKE_STATUS(0, ZYAN_MODULE_ZYCORE, 0x00)
 
 /**
- * @brief   The operation failed with an generic error.
+ * The operation failed with an generic error.
  */
 #define ZYAN_STATUS_FAILED \
     ZYAN_MAKE_STATUS(1, ZYAN_MODULE_ZYCORE, 0x01)
 
 /**
- * @brief   The operation completed successfully and returned `ZYAN_TRUE`.
+ * The operation completed successfully and returned `ZYAN_TRUE`.
  */
 #define ZYAN_STATUS_TRUE \
     ZYAN_MAKE_STATUS(0, ZYAN_MODULE_ZYCORE, 0x02)
 
 /**
- * @brief   The operation completed successfully and returned `ZYAN_FALSE`.
+ * The operation completed successfully and returned `ZYAN_FALSE`.
  */
 #define ZYAN_STATUS_FALSE \
     ZYAN_MAKE_STATUS(0, ZYAN_MODULE_ZYCORE, 0x03)
 
 /**
- * @brief   An invalid argument was passed to a function.
+ * An invalid argument was passed to a function.
  */
 #define ZYAN_STATUS_INVALID_ARGUMENT \
     ZYAN_MAKE_STATUS(1, ZYAN_MODULE_ZYCORE, 0x04)
 
 /**
- * @brief   An attempt was made to perform an invalid operation.
+ * An attempt was made to perform an invalid operation.
  */
 #define ZYAN_STATUS_INVALID_OPERATION \
     ZYAN_MAKE_STATUS(1, ZYAN_MODULE_ZYCORE, 0x05)
 
 /**
- * @brief   Insufficient privileges to perform the requested operation.
+ * Insufficient privileges to perform the requested operation.
  */
 #define ZYAN_STATUS_ACCESS_DENIED \
     ZYAN_MAKE_STATUS(1, ZYAN_MODULE_ZYCORE, 0x06)
 
 /**
- * @brief   The requested entity was not found.
+ * The requested entity was not found.
  */
 #define ZYAN_STATUS_NOT_FOUND \
     ZYAN_MAKE_STATUS(1, ZYAN_MODULE_ZYCORE, 0x07)
 
 /**
- * @brief   An index passed to a function was out of bounds.
+ * An index passed to a function was out of bounds.
  */
 #define ZYAN_STATUS_OUT_OF_RANGE \
     ZYAN_MAKE_STATUS(1, ZYAN_MODULE_ZYCORE, 0x08)
 
 /**
- * @brief   A buffer passed to a function was too small to complete the requested operation.
+ * A buffer passed to a function was too small to complete the requested operation.
  */
 #define ZYAN_STATUS_INSUFFICIENT_BUFFER_SIZE \
     ZYAN_MAKE_STATUS(1, ZYAN_MODULE_ZYCORE, 0x09)
 
 /**
- * @brief   Insufficient memory to perform the operation.
+ * Insufficient memory to perform the operation.
  */
 #define ZYAN_STATUS_NOT_ENOUGH_MEMORY \
     ZYAN_MAKE_STATUS(1, ZYAN_MODULE_ZYCORE, 0x0A)
 
 /**
- * @brief   An unknown error occurred during a system function call.
+ * An unknown error occurred during a system function call.
  */
 #define ZYAN_STATUS_BAD_SYSTEMCALL \
     ZYAN_MAKE_STATUS(1, ZYAN_MODULE_ZYCORE, 0x0B)
 
 /**
- * @brief   The process ran out of resources while performing an operation.
+ * The process ran out of resources while performing an operation.
  */
 #define ZYAN_STATUS_OUT_OF_RESOURCES \
     ZYAN_MAKE_STATUS(1, ZYAN_MODULE_ZYCORE, 0x0C)
 
 /**
- * @brief   A dependency library was not found or does have an unexpected version number or
- *          feature-set.
+ * A dependency library was not found or does have an unexpected version number or
+ * feature-set.
  */
 #define ZYAN_STATUS_MISSING_DEPENDENCY \
     ZYAN_MAKE_STATUS(1, ZYAN_MODULE_ZYCORE, 0x0D)
@@ -247,31 +247,31 @@ typedef ZyanU32 ZyanStatus;
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Argument was not expected.
+ * Argument was not expected.
  */
 #define ZYAN_STATUS_ARG_NOT_UNDERSTOOD \
     ZYAN_MAKE_STATUS(1, ZYAN_MODULE_ARGPARSE, 0x00)
 
 /**
- * @brief   Too few arguments were provided.
+ * Too few arguments were provided.
  */
 #define ZYAN_STATUS_TOO_FEW_ARGS \
     ZYAN_MAKE_STATUS(1, ZYAN_MODULE_ARGPARSE, 0x01)
 
 /**
- * @brief   Too many arguments were provided.
+ * Too many arguments were provided.
  */
 #define ZYAN_STATUS_TOO_MANY_ARGS \
     ZYAN_MAKE_STATUS(1, ZYAN_MODULE_ARGPARSE, 0x02)
 
 /**
- * @brief   An argument that expected a value misses its value.
+ * An argument that expected a value misses its value.
  */
 #define ZYAN_STATUS_ARG_MISSES_VALUE \
     ZYAN_MAKE_STATUS(1, ZYAN_MODULE_ARGPARSE, 0x03)
 
 /**
-* @brief   A required argument is missing.
+* A required argument is missing.
 */
 #define ZYAN_STATUS_REQUIRED_ARG_MISSING \
     ZYAN_MAKE_STATUS(1, ZYAN_MODULE_ARGPARSE, 0x04)

--- a/include/Zycore/String.h
+++ b/include/Zycore/String.h
@@ -26,7 +26,7 @@
 
 /**
  * @file
- * @brief   Implements a string type.
+ * Implements a string type.
  */
 
 #ifndef ZYCORE_STRING_H
@@ -47,18 +47,18 @@ extern "C" {
 /* ============================================================================================== */
 
 /**
- * @brief   The initial minimum capacity (number of characters) for all dynamically allocated
- *          string instances - not including the terminating '\0'-character.
+ * The initial minimum capacity (number of characters) for all dynamically allocated
+ * string instances - not including the terminating '\0'-character.
  */
 #define ZYAN_STRING_MIN_CAPACITY                32
 
 /**
- * @brief   The default growth factor for all string instances.
+ * The default growth factor for all string instances.
  */
 #define ZYAN_STRING_DEFAULT_GROWTH_FACTOR       2.00f
 
 /**
- * @brief   The default shrink threshold for all string instances.
+ * The default shrink threshold for all string instances.
  */
 #define ZYAN_STRING_DEFAULT_SHRINK_THRESHOLD    0.25f
 
@@ -71,12 +71,12 @@ extern "C" {
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Defines the `ZyanStringFlags` datatype.
+ * Defines the `ZyanStringFlags` datatype.
  */
 typedef ZyanU8 ZyanStringFlags;
 
 /**
- * @brief   The string uses a custom user-defined buffer with a fixed capacity.
+ * The string uses a custom user-defined buffer with a fixed capacity.
  */
 #define ZYAN_STRING_HAS_FIXED_CAPACITY  0x01 // (1 << 0)
 
@@ -85,7 +85,7 @@ typedef ZyanU8 ZyanStringFlags;
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Defines the `ZyanString` struct.
+ * Defines the `ZyanString` struct.
  *
  * The `ZyanString` type is implemented as a size-prefixed string - which allows for a lot of
  * performance optimizations.
@@ -98,11 +98,11 @@ typedef ZyanU8 ZyanStringFlags;
 typedef struct ZyanString_
 {
     /**
-     * @brief   String flags.
+     * String flags.
      */
     ZyanStringFlags flags;
     /**
-     * @brief   The vector that contains the actual string.
+     * The vector that contains the actual string.
      */
     ZyanVector vector;
 } ZyanString;
@@ -112,7 +112,7 @@ typedef struct ZyanString_
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Defines the `ZyanStringView` struct.
+ * Defines the `ZyanStringView` struct.
  *
  * The `ZyanStringView` type provides a view inside a string (`ZyanString` instances, null-
  * terminated C-style strings, or even not-null-terminated custom strings). A view is immutable
@@ -132,7 +132,7 @@ typedef struct ZyanString_
 typedef struct ZyanStringView_
 {
     /**
-     * @brief   The string data.
+     * The string data.
      *
      * The view internally re-uses the normal string struct to allow casts without any runtime
      * overhead.
@@ -151,7 +151,7 @@ typedef struct ZyanStringView_
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Defines an uninitialized `ZyanString` instance.
+ * Defines an uninitialized `ZyanString` instance.
  */
 #define ZYAN_STRING_INITIALIZER \
     { \
@@ -164,12 +164,12 @@ typedef struct ZyanStringView_
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Casts a `ZyanString` pointer to a constant `ZyanStringView` pointer.
+ * Casts a `ZyanString` pointer to a constant `ZyanStringView` pointer.
  */
 #define ZYAN_STRING_TO_VIEW(string) (const ZyanStringView*)(string)
 
 /**
- * @brief   Defines a `ZyanStringView` struct that provides a view into a static C-style string.
+ * Defines a `ZyanStringView` struct that provides a view into a static C-style string.
  *
  * @param   string  The C-style string.
  */
@@ -205,7 +205,7 @@ typedef struct ZyanStringView_
 #ifndef ZYAN_NO_LIBC
 
 /**
- * @brief   Initializes the given `ZyanString` instance.
+ * Initializes the given `ZyanString` instance.
  *
  * @param   string          A pointer to the `ZyanString` instance.
  * @param   capacity        The initial capacity (number of characters).
@@ -225,8 +225,8 @@ ZYCORE_EXPORT ZYAN_REQUIRES_LIBC ZyanStatus ZyanStringInit(ZyanString* string, Z
 #endif // ZYAN_NO_LIBC
 
 /**
- * @brief   Initializes the given `ZyanString` instance and sets a custom `allocator` and memory
- *          allocation/deallocation parameters.
+ * Initializes the given `ZyanString` instance and sets a custom `allocator` and memory
+ * allocation/deallocation parameters.
  *
  * @param   string              A pointer to the `ZyanString` instance.
  * @param   capacity            The initial capacity (number of characters).
@@ -248,8 +248,8 @@ ZYCORE_EXPORT ZyanStatus ZyanStringInitEx(ZyanString* string, ZyanUSize capacity
     ZyanAllocator* allocator, float growth_factor, float shrink_threshold);
 
 /**
- * @brief   Initializes the given `ZyanString` instance and configures it to use a custom user
- *          defined buffer with a fixed size.
+ * Initializes the given `ZyanString` instance and configures it to use a custom user
+ * defined buffer with a fixed size.
  *
  * @param   string          A pointer to the `ZyanString` instance.
  * @param   buffer          A pointer to the buffer that is used as storage for the string.
@@ -264,7 +264,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringInitCustomBuffer(ZyanString* string, char* bu
     ZyanUSize capacity);
 
 /**
- * @brief   Destroys the given `ZyanString` instance.
+ * Destroys the given `ZyanString` instance.
  *
  * @param   string  A pointer to the `ZyanString` instance.
  *
@@ -280,7 +280,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringDestroy(ZyanString* string);
 #ifndef ZYAN_NO_LIBC
 
 /**
- * @brief   Initializes a new `ZyanString` instance by duplicating an existing string.
+ * Initializes a new `ZyanString` instance by duplicating an existing string.
  *
  * @param   destination A pointer to the (uninitialized) destination `ZyanString` instance.
  * @param   source      A pointer to the source string.
@@ -308,8 +308,8 @@ ZYCORE_EXPORT ZYAN_REQUIRES_LIBC ZyanStatus ZyanStringDuplicate(ZyanString* dest
 #endif // ZYAN_NO_LIBC
 
 /**
- * @brief   Initializes a new `ZyanString` instance by duplicating an existing string and sets a
- *          custom `allocator` and memory allocation/deallocation parameters.
+ * Initializes a new `ZyanString` instance by duplicating an existing string and sets a
+ * custom `allocator` and memory allocation/deallocation parameters.
  *
  * @param   destination         A pointer to the (uninitialized) destination `ZyanString` instance.
  * @param   source              A pointer to the source string.
@@ -339,8 +339,8 @@ ZYCORE_EXPORT ZyanStatus ZyanStringDuplicateEx(ZyanString* destination,
     float growth_factor, float shrink_threshold);
 
 /**
- * @brief   Initializes a new `ZyanString` instance by duplicating an existing string and
- *          configures it to use a custom user defined buffer with a fixed size.
+ * Initializes a new `ZyanString` instance by duplicating an existing string and
+ * configures it to use a custom user defined buffer with a fixed size.
  *
  * @param   destination A pointer to the (uninitialized) destination `ZyanString` instance.
  * @param   source      A pointer to the source string.
@@ -368,7 +368,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringDuplicateCustomBuffer(ZyanString* destination
 #ifndef ZYAN_NO_LIBC
 
 /**
- * @brief   Initializes a new `ZyanString` instance by concatenating two existing strings.
+ * Initializes a new `ZyanString` instance by concatenating two existing strings.
  *
  * @param   destination A pointer to the (uninitialized) destination `ZyanString` instance.
  *
@@ -400,8 +400,8 @@ ZYCORE_EXPORT ZYAN_REQUIRES_LIBC ZyanStatus ZyanStringConcat(ZyanString* destina
 #endif // ZYAN_NO_LIBC
 
 /**
- * @brief   Initializes a new `ZyanString` instance by concatenating two existing strings and sets
- *          a custom `allocator` and memory allocation/deallocation parameters.
+ * Initializes a new `ZyanString` instance by concatenating two existing strings and sets
+ * a custom `allocator` and memory allocation/deallocation parameters.
  *
  * @param   destination         A pointer to the (uninitialized) destination `ZyanString` instance.
  *
@@ -435,8 +435,8 @@ ZYCORE_EXPORT ZyanStatus ZyanStringConcatEx(ZyanString* destination, const ZyanS
     float shrink_threshold);
 
 /**
- * @brief   Initializes a new `ZyanString` instance by concatenating two existing strings and
- *          configures it to use a custom user defined buffer with a fixed size.
+ * Initializes a new `ZyanString` instance by concatenating two existing strings and
+ * configures it to use a custom user defined buffer with a fixed size.
  *
  * @param   destination A pointer to the (uninitialized) destination `ZyanString` instance.
  *
@@ -465,7 +465,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringConcatCustomBuffer(ZyanString* destination,
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Returns a view inside an existing view/string.
+ * Returns a view inside an existing view/string.
  *
  * @param   view    A pointer to the `ZyanStringView` instance.
  * @param   source  A pointer to the source string.
@@ -479,7 +479,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringViewInsideView(ZyanStringView* view,
     const ZyanStringView* source);
 
 /**
- * @brief   Returns a view inside an existing view/string starting from the given `index`.
+ * Returns a view inside an existing view/string starting from the given `index`.
  *
  * @param   view    A pointer to the `ZyanStringView` instance.
  * @param   source  A pointer to the source string.
@@ -495,7 +495,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringViewInsideViewEx(ZyanStringView* view,
     const ZyanStringView* source, ZyanUSize index, ZyanUSize count);
 
 /**
- * @brief   Returns a view inside a null-terminated C-style string.
+ * Returns a view inside a null-terminated C-style string.
  *
  * @param   view    A pointer to the `ZyanStringView` instance.
  * @param   string  The C-style string.
@@ -505,7 +505,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringViewInsideViewEx(ZyanStringView* view,
 ZYCORE_EXPORT ZyanStatus ZyanStringViewInsideBuffer(ZyanStringView* view, const char* string);
 
 /**
- * @brief   Returns a view inside a character buffer with custom length.
+ * Returns a view inside a character buffer with custom length.
  *
  * @param   view    A pointer to the `ZyanStringView` instance.
  * @param   buffer  A pointer to the buffer containing the string characters.
@@ -517,7 +517,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringViewInsideBufferEx(ZyanStringView* view, cons
     ZyanUSize length);
 
 /**
- * @brief   Returns the size (number of characters) of the view.
+ * Returns the size (number of characters) of the view.
  *
  * @param   view    A pointer to the `ZyanStringView` instance.
  * @param   size    Receives the size (number of characters) of the view.
@@ -527,7 +527,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringViewInsideBufferEx(ZyanStringView* view, cons
 ZYCORE_EXPORT ZyanStatus ZyanStringViewGetSize(const ZyanStringView* view, ZyanUSize* size);
 
 /**
- * @brief   Returns the C-style string of the given `ZyanString` instance.
+ * Returns the C-style string of the given `ZyanString` instance.
  *
  * @warning The string is not guaranteed to be null terminated!
  *
@@ -543,7 +543,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringViewGetData(const ZyanStringView* view, const
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Returns the character at the given `index`.
+ * Returns the character at the given `index`.
  *
  * @param   string  A pointer to the `ZyanStringView` instance.
  * @param   index   The character index.
@@ -555,7 +555,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringGetChar(const ZyanStringView* string, ZyanUSi
     char* value);
 
 /**
- * @brief   Returns a pointer to the character at the given `index`.
+ * Returns a pointer to the character at the given `index`.
  *
  * @param   string  A pointer to the `ZyanString` instance.
  * @param   index   The character index.
@@ -567,7 +567,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringGetCharMutable(ZyanString* string, ZyanUSize 
     char** value);
 
 /**
- * @brief   Assigns a new value to the character at the given `index`.
+ * Assigns a new value to the character at the given `index`.
  *
  * @param   string  A pointer to the `ZyanString` instance.
  * @param   index   The character index.
@@ -582,7 +582,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringSetChar(ZyanString* string, ZyanUSize index, 
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Inserts the content of the source string in the destination string at the given `index`.
+ * Inserts the content of the source string in the destination string at the given `index`.
  *
  * @param   destination The destination string.
  * @param   index       The insert index.
@@ -594,8 +594,8 @@ ZYCORE_EXPORT ZyanStatus ZyanStringInsert(ZyanString* destination, ZyanUSize ind
     const ZyanStringView* source);
 
 /**
- * @brief   Inserts `count` characters of the source string in the destination string at the given
- *          `index`.
+ * Inserts `count` characters of the source string in the destination string at the given
+ * `index`.
  *
  * @param   destination         The destination string.
  * @param   destination_index   The insert index.
@@ -614,7 +614,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringInsertEx(ZyanString* destination, ZyanUSize d
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Appends the content of the source string to the end of the destination string.
+ * Appends the content of the source string to the end of the destination string.
  *
  * @param   destination The destination string.
  * @param   source      The source string.
@@ -624,7 +624,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringInsertEx(ZyanString* destination, ZyanUSize d
 ZYCORE_EXPORT ZyanStatus ZyanStringAppend(ZyanString* destination, const ZyanStringView* source);
 
 /**
- * @brief   Appends `count` characters of the source string to the end of the destination string.
+ * Appends `count` characters of the source string to the end of the destination string.
  *
  * @param   destination     The destination string.
  * @param   source          The source string.
@@ -641,7 +641,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringAppendEx(ZyanString* destination, const ZyanS
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Deletes characters from the given string, starting at `index`.
+ * Deletes characters from the given string, starting at `index`.
  *
  * @param   string  A pointer to the `ZyanString` instance.
  * @param   index   The index of the first character to delete.
@@ -652,7 +652,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringAppendEx(ZyanString* destination, const ZyanS
 ZYCORE_EXPORT ZyanStatus ZyanStringDelete(ZyanString* string, ZyanUSize index, ZyanUSize count);
 
 /**
- * @brief   Deletes all remaining characters from the given string, starting at `index`.
+ * Deletes all remaining characters from the given string, starting at `index`.
  *
  * @param   string  A pointer to the `ZyanString` instance.
  * @param   index   The index of the first character to delete.
@@ -662,7 +662,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringDelete(ZyanString* string, ZyanUSize index, Z
 ZYCORE_EXPORT ZyanStatus ZyanStringTruncate(ZyanString* string, ZyanUSize index);
 
 /**
- * @brief   Erases the given string.
+ * Erases the given string.
  *
  * @param   string  A pointer to the `ZyanString` instance.
  *
@@ -675,8 +675,8 @@ ZYCORE_EXPORT ZyanStatus ZyanStringClear(ZyanString* string);
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Searches for the first occurrence of `needle` in the given `haystack` starting from the
- *          left.
+ * Searches for the first occurrence of `needle` in the given `haystack` starting from the
+ * left.
  *
  * @param   haystack    The string to search in.
  * @param   needle      The sub-string to search for.
@@ -692,8 +692,8 @@ ZYCORE_EXPORT ZyanStatus ZyanStringLPos(const ZyanStringView* haystack,
     const ZyanStringView* needle, ZyanISize* found_index);
 
 /**
- * @brief   Searches for the first occurrence of `needle` in the given `haystack` starting from the
- *          left.
+ * Searches for the first occurrence of `needle` in the given `haystack` starting from the
+ * left.
  *
  * @param   haystack    The string to search in.
  * @param   needle      The sub-string to search for.
@@ -712,8 +712,8 @@ ZYCORE_EXPORT ZyanStatus ZyanStringLPosEx(const ZyanStringView* haystack,
     const ZyanStringView* needle, ZyanISize* found_index, ZyanUSize index, ZyanUSize count);
 
 /**
- * @brief   Performs a case-insensitive search for the first occurrence of `needle` in the given
- *          `haystack` starting from the left.
+ * Performs a case-insensitive search for the first occurrence of `needle` in the given
+ * `haystack` starting from the left.
  *
  * @param   haystack    The string to search in.
  * @param   needle      The sub-string to search for.
@@ -729,8 +729,8 @@ ZYCORE_EXPORT ZyanStatus ZyanStringLPosI(const ZyanStringView* haystack,
     const ZyanStringView* needle, ZyanISize* found_index);
 
 /**
- * @brief   Performs a case-insensitive search for the first occurrence of `needle` in the given
- *          `haystack` starting from the left.
+ * Performs a case-insensitive search for the first occurrence of `needle` in the given
+ * `haystack` starting from the left.
  *
  * @param   haystack    The string to search in.
  * @param   needle      The sub-string to search for.
@@ -749,8 +749,8 @@ ZYCORE_EXPORT ZyanStatus ZyanStringLPosIEx(const ZyanStringView* haystack,
     const ZyanStringView* needle, ZyanISize* found_index, ZyanUSize index, ZyanUSize count);
 
 /**
- * @brief   Searches for the first occurrence of `needle` in the given `haystack` starting from the
- *          right.
+ * Searches for the first occurrence of `needle` in the given `haystack` starting from the
+ * right.
  *
  * @param   haystack    The string to search in.
  * @param   needle      The sub-string to search for.
@@ -766,7 +766,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringRPos(const ZyanStringView* haystack,
     const ZyanStringView* needle, ZyanISize* found_index);
 
 /**
- * @brief   Searches for the first occurrence of `needle` in the given `haystack` starting from the
+ * Searches for the first occurrence of `needle` in the given `haystack` starting from the
  *          right.
  *
  * @param   haystack    The string to search in.
@@ -786,8 +786,8 @@ ZYCORE_EXPORT ZyanStatus ZyanStringRPosEx(const ZyanStringView* haystack,
     const ZyanStringView* needle, ZyanISize* found_index, ZyanUSize index, ZyanUSize count);
 
 /**
- * @brief   Performs a case-insensitive search for the first occurrence of `needle` in the given
- *          `haystack` starting from the right.
+ * Performs a case-insensitive search for the first occurrence of `needle` in the given
+ * `haystack` starting from the right.
  *
  * @param   haystack    The string to search in.
  * @param   needle      The sub-string to search for.
@@ -803,8 +803,8 @@ ZYCORE_EXPORT ZyanStatus ZyanStringRPosI(const ZyanStringView* haystack,
     const ZyanStringView* needle, ZyanISize* found_index);
 
 /**
- * @brief   Performs a case-insensitive search for the first occurrence of `needle` in the given
- *          `haystack` starting from the right.
+ * Performs a case-insensitive search for the first occurrence of `needle` in the given
+ * `haystack` starting from the right.
  *
  * @param   haystack    The string to search in.
  * @param   needle      The sub-string to search for.
@@ -827,7 +827,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringRPosIEx(const ZyanStringView* haystack,
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Compares two strings.
+ * Compares two strings.
  *
  * @param   s1      The first string
  * @param   s2      The second string.
@@ -847,7 +847,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringCompare(const ZyanStringView* s1, const ZyanS
     ZyanI32* result);
 
 /**
- * @brief   Performs a case-insensitive comparison of two strings.
+ * Performs a case-insensitive comparison of two strings.
  *
  * @param   s1      The first string
  * @param   s2      The second string.
@@ -871,7 +871,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringCompareI(const ZyanStringView* s1, const Zyan
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Converts the given string to lowercase letters.
+ * Converts the given string to lowercase letters.
  *
  * @param   string      A pointer to the `ZyanString` instance.
  *
@@ -883,7 +883,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringCompareI(const ZyanStringView* s1, const Zyan
 ZYCORE_EXPORT ZyanStatus ZyanStringToLowerCase(ZyanString* string);
 
 /**
- * @brief   Converts `count` characters of the given string to lowercase letters.
+ * Converts `count` characters of the given string to lowercase letters.
  *
  * @param   string  A pointer to the `ZyanString` instance.
  * @param   index   The start index.
@@ -898,7 +898,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringToLowerCaseEx(ZyanString* string, ZyanUSize i
     ZyanUSize count);
 
 /**
- * @brief   Converts the given string to uppercase letters.
+ * Converts the given string to uppercase letters.
  *
  * @param   string      A pointer to the `ZyanString` instance.
  *
@@ -910,7 +910,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringToLowerCaseEx(ZyanString* string, ZyanUSize i
 ZYCORE_EXPORT ZyanStatus ZyanStringToUpperCase(ZyanString* string);
 
 /**
- * @brief   Converts `count` characters of the given string to uppercase letters.
+ * Converts `count` characters of the given string to uppercase letters.
  *
  * @param   string  A pointer to the `ZyanString` instance.
  * @param   index   The start index.
@@ -929,7 +929,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringToUpperCaseEx(ZyanString* string, ZyanUSize i
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Resizes the given `ZyanString` instance.
+ * Resizes the given `ZyanString` instance.
  *
  * @param   string  A pointer to the `ZyanString` instance.
  * @param   size    The new size of the string.
@@ -942,7 +942,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringToUpperCaseEx(ZyanString* string, ZyanUSize i
 ZYCORE_EXPORT ZyanStatus ZyanStringResize(ZyanString* string, ZyanUSize size);
 
 /**
- * @brief   Changes the capacity of the given `ZyanString` instance.
+ * Changes the capacity of the given `ZyanString` instance.
  *
  * @param   string      A pointer to the `ZyanString` instance.
  * @param   capacity    The new minimum capacity of the string.
@@ -955,7 +955,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringResize(ZyanString* string, ZyanUSize size);
 ZYCORE_EXPORT ZyanStatus ZyanStringReserve(ZyanString* string, ZyanUSize capacity);
 
 /**
- * @brief   Shrinks the capacity of the given string to match it's size.
+ * Shrinks the capacity of the given string to match it's size.
  *
  * @param   string  A pointer to the `ZyanString` instance.
  *
@@ -971,7 +971,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringShrinkToFit(ZyanString* string);
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Returns the current capacity of the string.
+ * Returns the current capacity of the string.
  *
  * @param   string      A pointer to the `ZyanString` instance.
  * @param   capacity    Receives the size of the string.
@@ -981,8 +981,8 @@ ZYCORE_EXPORT ZyanStatus ZyanStringShrinkToFit(ZyanString* string);
 ZYCORE_EXPORT ZyanStatus ZyanStringGetCapacity(const ZyanString* string, ZyanUSize* capacity);
 
 /**
- * @brief   Returns the current size (number of characters) of the string (excluding the
- *          terminating zero character).
+ * Returns the current size (number of characters) of the string (excluding the
+ * terminating zero character).
  *
  * @param   string  A pointer to the `ZyanString` instance.
  * @param   size    Receives the size (number of characters) of the string.
@@ -992,7 +992,7 @@ ZYCORE_EXPORT ZyanStatus ZyanStringGetCapacity(const ZyanString* string, ZyanUSi
 ZYCORE_EXPORT ZyanStatus ZyanStringGetSize(const ZyanString* string, ZyanUSize* size);
 
 /**
- * @brief   Returns the C-style string of the given `ZyanString` instance.
+ * Returns the C-style string of the given `ZyanString` instance.
  *
  * @param   string  A pointer to the `ZyanString` instance.
  * @param   value   Receives a pointer to the C-style string.

--- a/include/Zycore/Types.h
+++ b/include/Zycore/Types.h
@@ -26,7 +26,7 @@
 
 /**
  * @file
- * @brief   Includes and defines some default data types.
+ * Includes and defines some default data types.
  */
 
 #ifndef ZYCORE_TYPES_H
@@ -120,12 +120,12 @@ ZYAN_STATIC_ASSERT((ZyanI64)-1 >> 1 < (ZyanI64)((ZyanU64)-1 >> 1));
 /* ============================================================================================== */
 
 /**
- * @brief   Defines the `ZyanVoidPointer` data-type.
+ * Defines the `ZyanVoidPointer` data-type.
  */
 typedef char* ZyanVoidPointer;
 
 /**
- * @brief   Defines the `ZyanConstVoidPointer` data-type.
+ * Defines the `ZyanConstVoidPointer` data-type.
  */
 typedef const void* ZyanConstVoidPointer;
 
@@ -143,7 +143,7 @@ typedef const void* ZyanConstVoidPointer;
 #define ZYAN_TRUE  1
 
 /**
- * @brief   Defines the `ZyanBool` data-type.
+ * Defines the `ZyanBool` data-type.
  *
  * Represents a default boolean data-type where `0` is interpreted as `false` and all other values
  * as `true`.
@@ -155,7 +155,7 @@ typedef ZyanU8 ZyanBool;
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Defines the `ZyanTernary` data-type.
+ * Defines the `ZyanTernary` data-type.
  *
  * The `ZyanTernary` is a balanced ternary type that uses three truth values indicating `true`,
  * `false` and an indeterminate third value.
@@ -175,14 +175,14 @@ typedef ZyanI8 ZyanTernary;
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Defines the `ZyanCharPointer` data-type.
+ * Defines the `ZyanCharPointer` data-type.
  *
  * This type is most often used to represent null-terminated strings aka. C-style strings.
  */
 typedef char* ZyanCharPointer;
 
 /**
- * @brief   Defines the `ZyanConstCharPointer` data-type.
+ * Defines the `ZyanConstCharPointer` data-type.
  *
  * This type is most often used to represent null-terminated strings aka. C-style strings.
  */

--- a/include/Zycore/Vector.h
+++ b/include/Zycore/Vector.h
@@ -26,7 +26,7 @@
 
 /**
  * @file
- * @brief   Implements the vector container class.
+ * Implements the vector container class.
  */
 
 #ifndef ZYCORE_VECTOR_H
@@ -48,18 +48,18 @@ extern "C" {
 /* ============================================================================================== */
 
 /**
- * @brief   The initial minimum capacity (number of elements) for all dynamically allocated vector
- *          instances.
+ * The initial minimum capacity (number of elements) for all dynamically allocated vector
+ * instances.
  */
 #define ZYAN_VECTOR_MIN_CAPACITY                1
 
 /**
- * @brief   The default growth factor for all vector instances.
+ * The default growth factor for all vector instances.
  */
 #define ZYAN_VECTOR_DEFAULT_GROWTH_FACTOR       2.00f
 
 /**
- * @brief   The default shrink threshold for all vector instances.
+ * The default shrink threshold for all vector instances.
  */
 #define ZYAN_VECTOR_DEFAULT_SHRINK_THRESHOLD    0.25f
 
@@ -68,7 +68,7 @@ extern "C" {
 /* ============================================================================================== */
 
 /**
- * @brief   Defines the `ZyanVector` struct.
+ * Defines the `ZyanVector` struct.
  *
  * All fields in this struct should be considered as "private". Any changes may lead to unexpected
  * behavior.
@@ -76,35 +76,35 @@ extern "C" {
 typedef struct ZyanVector_
 {
     /**
-     * @brief   The memory allocator.
+     * The memory allocator.
      */
     ZyanAllocator* allocator;
     /**
-     * @brief   The growth factor.
+     * The growth factor.
      */
     float growth_factor;
     /**
-     * @brief   The shrink threshold.
+     * The shrink threshold.
      */
     float shrink_threshold;
     /**
-     * @brief   The current number of elements in the vector.
+     * The current number of elements in the vector.
      */
     ZyanUSize size;
     /**
-     * @brief   The maximum capacity (number of elements).
+     * The maximum capacity (number of elements).
      */
     ZyanUSize capacity;
     /**
-     * @brief   The size of a single element in bytes.
+     * The size of a single element in bytes.
      */
     ZyanUSize element_size;
     /**
-     * @brief   The element destructor callback.   
+     * The element destructor callback.
      */
     ZyanMemberProcedure destructor;
     /**
-     * @brief   The data pointer.
+     * The data pointer.
      */
     void* data;
 } ZyanVector;
@@ -118,7 +118,7 @@ typedef struct ZyanVector_
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Defines an uninitialized `ZyanVector` instance.
+ * Defines an uninitialized `ZyanVector` instance.
  */
 #define ZYAN_VECTOR_INITIALIZER \
     { \
@@ -137,7 +137,7 @@ typedef struct ZyanVector_
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Returns the value of the element at the given `index`.
+ * Returns the value of the element at the given `index`.
  *
  * @param   type    The desired value type.
  * @param   vector  A pointer to the `ZyanVector` instance.
@@ -156,7 +156,7 @@ typedef struct ZyanVector_
 #endif
 
 /**
- * @brief   Loops through all elements of the vector.
+ * Loops through all elements of the vector.
  *
  * @param   type        The desired value type.
  * @param   vector      A pointer to the `ZyanVector` instance.
@@ -178,7 +178,7 @@ typedef struct ZyanVector_
     }
 
 /**
- * @brief   Loops through all elements of the vector.
+ * Loops through all elements of the vector.
  *
  * @param   type        The desired value type.
  * @param   vector      A pointer to the `ZyanVector` instance.
@@ -212,7 +212,7 @@ typedef struct ZyanVector_
 #ifndef ZYAN_NO_LIBC
 
 /**
- * @brief   Initializes the given `ZyanVector` instance.
+ * Initializes the given `ZyanVector` instance.
  *
  * @param   vector          A pointer to the `ZyanVector` instance.
  * @param   element_size    The size of a single element in bytes.
@@ -233,13 +233,13 @@ ZYCORE_EXPORT ZYAN_REQUIRES_LIBC ZyanStatus ZyanVectorInit(ZyanVector* vector,
 #endif // ZYAN_NO_LIBC
 
 /**
- * @brief   Initializes the given `ZyanVector` instance and sets a custom `allocator` and memory
- *          allocation/deallocation parameters.
+ * Initializes the given `ZyanVector` instance and sets a custom `allocator` and memory
+ * allocation/deallocation parameters.
  *
  * @param   vector              A pointer to the `ZyanVector` instance.
  * @param   element_size        The size of a single element in bytes.
  * @param   capacity            The initial capacity (number of elements).
- * @param   destructor          A destructor callback that is invoked every time an item is deleted, 
+ * @param   destructor          A destructor callback that is invoked every time an item is deleted,
  *                              or `ZYAN_NULL` if not needed.
  * @param   allocator           A pointer to a `ZyanAllocator` instance.
  * @param   growth_factor       The growth factor (from `1.0f` to `x.xf`).
@@ -253,12 +253,12 @@ ZYCORE_EXPORT ZYAN_REQUIRES_LIBC ZyanStatus ZyanVectorInit(ZyanVector* vector,
  * Finalization with `ZyanVectorDestroy` is required for all instances created by this function.
  */
 ZYCORE_EXPORT ZyanStatus ZyanVectorInitEx(ZyanVector* vector, ZyanUSize element_size,
-    ZyanUSize capacity, ZyanMemberProcedure destructor, ZyanAllocator* allocator, 
+    ZyanUSize capacity, ZyanMemberProcedure destructor, ZyanAllocator* allocator,
     float growth_factor, float shrink_threshold);
 
 /**
- * @brief   Initializes the given `ZyanVector` instance and configures it to use a custom user
- *          defined buffer with a fixed size.
+ * Initializes the given `ZyanVector` instance and configures it to use a custom user
+ * defined buffer with a fixed size.
  *
  * @param   vector          A pointer to the `ZyanVector` instance.
  * @param   element_size    The size of a single element in bytes.
@@ -275,7 +275,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorInitCustomBuffer(ZyanVector* vector, ZyanUSiz
     void* buffer, ZyanUSize capacity, ZyanMemberProcedure destructor);
 
 /**
- * @brief   Destroys the given `ZyanVector` instance.
+ * Destroys the given `ZyanVector` instance.
  *
  * @param   vector  A pointer to the `ZyanVector` instance..
  *
@@ -290,7 +290,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorDestroy(ZyanVector* vector);
 #ifndef ZYAN_NO_LIBC
 
 /**
- * @brief   Initializes a new `ZyanVector` instance by duplicating an existing vector.
+ * Initializes a new `ZyanVector` instance by duplicating an existing vector.
  *
  * @param   destination A pointer to the (uninitialized) destination `ZyanVector` instance.
  * @param   source      A pointer to the source vector.
@@ -312,8 +312,8 @@ ZYCORE_EXPORT ZYAN_REQUIRES_LIBC ZyanStatus ZyanVectorDuplicate(ZyanVector* dest
 #endif // ZYAN_NO_LIBC
 
 /**
- * @brief   Initializes a new `ZyanVector` instance by duplicating an existing vector and sets a
- *          custom `allocator` and memory allocation/deallocation parameters.
+ * Initializes a new `ZyanVector` instance by duplicating an existing vector and sets a
+ * custom `allocator` and memory allocation/deallocation parameters.
  *
  * @param   destination         A pointer to the (uninitialized) destination `ZyanVector` instance.
  * @param   source              A pointer to the source vector.
@@ -336,8 +336,8 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorDuplicateEx(ZyanVector* destination, const Zy
     ZyanUSize capacity, ZyanAllocator* allocator, float growth_factor, float shrink_threshold);
 
 /**
- * @brief   Initializes a new `ZyanVector` instance by duplicating an existing vector and
- *          configures it to use a custom user defined buffer with a fixed size.
+ * Initializes a new `ZyanVector` instance by duplicating an existing vector and
+ * configures it to use a custom user defined buffer with a fixed size.
  *
  * @param   destination A pointer to the (uninitialized) destination `ZyanVector` instance.
  * @param   source      A pointer to the source vector.
@@ -359,7 +359,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorDuplicateCustomBuffer(ZyanVector* destination
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Returns a constant pointer to the element at the given `index`.
+ * Returns a constant pointer to the element at the given `index`.
  *
  * @param   vector      A pointer to the `ZyanVector` instance.
  * @param   index       The element index.
@@ -376,7 +376,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorDuplicateCustomBuffer(ZyanVector* destination
 ZYCORE_EXPORT const void* ZyanVectorGet(const ZyanVector* vector, ZyanUSize index);
 
 /**
- * @brief   Returns a mutable pointer to the element at the given `index`.
+ * Returns a mutable pointer to the element at the given `index`.
  *
  * @param   vector      A pointer to the `ZyanVector` instance.
  * @param   index       The element index.
@@ -393,7 +393,7 @@ ZYCORE_EXPORT const void* ZyanVectorGet(const ZyanVector* vector, ZyanUSize inde
 ZYCORE_EXPORT void* ZyanVectorGetMutable(const ZyanVector* vector, ZyanUSize index);
 
 /**
- * @brief   Returns a constant pointer to the element at the given `index`.
+ * Returns a constant pointer to the element at the given `index`.
  *
  * @param   vector  A pointer to the `ZyanVector` instance.
  * @param   index   The element index.
@@ -408,7 +408,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorGetPointer(const ZyanVector* vector, ZyanUSiz
     const void** value);
 
 /**
- * @brief   Returns a mutable pointer to the element at the given `index`.
+ * Returns a mutable pointer to the element at the given `index`.
  *
  * @param   vector  A pointer to the `ZyanVector` instance.
  * @param   index   The element index.
@@ -423,7 +423,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorGetPointerMutable(const ZyanVector* vector, Z
     void** value);
 
 /**
- * @brief   Assigns a new value to the element at the given `index`.
+ * Assigns a new value to the element at the given `index`.
  *
  * @param   vector  A pointer to the `ZyanVector` instance.
  * @param   index   The value index.
@@ -439,7 +439,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorSet(ZyanVector* vector, ZyanUSize index,
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Adds a new `element` to the end of the vector.
+ * Adds a new `element` to the end of the vector.
  *
  * @param   vector  A pointer to the `ZyanVector` instance.
  * @param   element A pointer to the element to add.
@@ -449,7 +449,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorSet(ZyanVector* vector, ZyanUSize index,
 ZYCORE_EXPORT ZyanStatus ZyanVectorPushBack(ZyanVector* vector, const void* element);
 
 /**
- * @brief   Inserts an `element` at the given `index` of the vector.
+ * Inserts an `element` at the given `index` of the vector.
  *
  * @param   vector  A pointer to the `ZyanVector` instance.
  * @param   index   The insert index.
@@ -461,7 +461,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorInsert(ZyanVector* vector, ZyanUSize index,
     const void* element);
 
 /**
- * @brief   Inserts multiple `elements` at the given `index` of the vector.
+ * Inserts multiple `elements` at the given `index` of the vector.
  *
  * @param   vector      A pointer to the `ZyanVector` instance.
  * @param   index       The insert index.
@@ -474,7 +474,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorInsertRange(ZyanVector* vector, ZyanUSize ind
     const void* elements, ZyanUSize count);
 
 /**
- * @brief   Constructs an `element` in-place at the end of the vector.
+ * Constructs an `element` in-place at the end of the vector.
  *
  * @param   vector      A pointer to the `ZyanVector` instance.
  * @param   element     Receives a pointer to the new element.
@@ -487,7 +487,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorEmplace(ZyanVector* vector, void** element,
     ZyanMemberFunction constructor);
 
 /**
- * @brief   Constructs an `element` in-place and inserts it at the given `index` of the vector.
+ * Constructs an `element` in-place and inserts it at the given `index` of the vector.
  *
  * @param   vector      A pointer to the `ZyanVector` instance.
  * @param   index       The insert index.
@@ -505,7 +505,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorEmplaceEx(ZyanVector* vector, ZyanUSize index
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Swaps the element at `index_first` with the element at `index_second`.
+ * Swaps the element at `index_first` with the element at `index_second`.
  *
  * @param   vector          A pointer to the `ZyanVector` instance.
  * @param   index_first     The index of the first element.
@@ -524,7 +524,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorSwapElements(ZyanVector* vector, ZyanUSize in
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Deletes the element at the given `index` of the vector.
+ * Deletes the element at the given `index` of the vector.
  *
  * @param   vector  A pointer to the `ZyanVector` instance.
  * @param   index   The element index.
@@ -534,7 +534,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorSwapElements(ZyanVector* vector, ZyanUSize in
 ZYCORE_EXPORT ZyanStatus ZyanVectorDelete(ZyanVector* vector, ZyanUSize index);
 
 /**
- * @brief   Deletes multiple elements from the given vector, starting at `index`.
+ * Deletes multiple elements from the given vector, starting at `index`.
  *
  * @param   vector  A pointer to the `ZyanVector` instance.
  * @param   index   The index of the first element to delete.
@@ -542,11 +542,11 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorDelete(ZyanVector* vector, ZyanUSize index);
  *
  * @return  A zyan status code.
  */
-ZYCORE_EXPORT ZyanStatus ZyanVectorDeleteRange(ZyanVector* vector, ZyanUSize index, 
+ZYCORE_EXPORT ZyanStatus ZyanVectorDeleteRange(ZyanVector* vector, ZyanUSize index,
     ZyanUSize count);
 
 /**
- * @brief   Removes the last element of the vector.
+ * Removes the last element of the vector.
  *
  * @param   vector  A pointer to the `ZyanVector` instance.
  *
@@ -555,7 +555,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorDeleteRange(ZyanVector* vector, ZyanUSize ind
 ZYCORE_EXPORT ZyanStatus ZyanVectorPopBack(ZyanVector* vector);
 
 /**
- * @brief   Erases all elements of the given vector.
+ * Erases all elements of the given vector.
  *
  * @param   vector  A pointer to the `ZyanVector` instance.
  *
@@ -568,7 +568,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorClear(ZyanVector* vector);
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Sequentially searches for the first occurrence of `element` in the given vector.
+ * Sequentially searches for the first occurrence of `element` in the given vector.
  *
  * @param   vector      A pointer to the `ZyanVector` instance.
  * @param   element     A pointer to the element to search for.
@@ -584,7 +584,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorFind(const ZyanVector* vector, const void* el
     ZyanISize* found_index, ZyanEqualityComparison comparison);
 
 /**
- * @brief   Sequentially searches for the first occurrence of `element` in the given vector.
+ * Sequentially searches for the first occurrence of `element` in the given vector.
  *
  * @param   vector      A pointer to the `ZyanVector` instance.
  * @param   element     A pointer to the element to search for.
@@ -602,8 +602,8 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorFindEx(const ZyanVector* vector, const void* 
     ZyanISize* found_index, ZyanEqualityComparison comparison, ZyanUSize index, ZyanUSize count);
 
 /**
- * @brief   Searches for the first occurrence of `element` in the given vector using a binary-
- *          search algorithm.
+ * Searches for the first occurrence of `element` in the given vector using a binary-
+ * search algorithm.
  *
  * @param   vector      A pointer to the `ZyanVector` instance.
  * @param   element     A pointer to the element to search for.
@@ -622,8 +622,8 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorBinarySearch(const ZyanVector* vector, const 
     ZyanUSize* found_index, ZyanComparison comparison);
 
 /**
- * @brief   Searches for the first occurrence of `element` in the given vector using a binary-
- *          search algorithm.
+ * Searches for the first occurrence of `element` in the given vector using a binary-
+ * search algorithm.
  *
  * @param   vector      A pointer to the `ZyanVector` instance.
  * @param   element     A pointer to the element to search for.
@@ -648,7 +648,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorBinarySearchEx(const ZyanVector* vector, cons
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Resizes the given `ZyanVector` instance.
+ * Resizes the given `ZyanVector` instance.
  *
  * @param   vector  A pointer to the `ZyanVector` instance.
  * @param   size    The new size of the vector.
@@ -658,7 +658,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorBinarySearchEx(const ZyanVector* vector, cons
 ZYCORE_EXPORT ZyanStatus ZyanVectorResize(ZyanVector* vector, ZyanUSize size);
 
 /**
- * @brief   Resizes the given `ZyanVector` instance.
+ * Resizes the given `ZyanVector` instance.
  *
  * @param   vector      A pointer to the `ZyanVector` instance.
  * @param   size        The new size of the vector.
@@ -666,11 +666,11 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorResize(ZyanVector* vector, ZyanUSize size);
  *
  * @return  A zyan status code.
  */
-ZYCORE_EXPORT ZyanStatus ZyanVectorResizeEx(ZyanVector* vector, ZyanUSize size, 
+ZYCORE_EXPORT ZyanStatus ZyanVectorResizeEx(ZyanVector* vector, ZyanUSize size,
     const void* initializer);
 
 /**
- * @brief   Changes the capacity of the given `ZyanVector` instance.
+ * Changes the capacity of the given `ZyanVector` instance.
  *
  * @param   vector      A pointer to the `ZyanVector` instance.
  * @param   capacity    The new minimum capacity of the vector.
@@ -680,7 +680,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorResizeEx(ZyanVector* vector, ZyanUSize size,
 ZYCORE_EXPORT ZyanStatus ZyanVectorReserve(ZyanVector* vector, ZyanUSize capacity);
 
 /**
- * @brief   Shrinks the capacity of the given vector to match it's size.
+ * Shrinks the capacity of the given vector to match it's size.
  *
  * @param   vector  A pointer to the `ZyanVector` instance.
  *
@@ -693,7 +693,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorShrinkToFit(ZyanVector* vector);
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Returns the current capacity of the vector.
+ * Returns the current capacity of the vector.
  *
  * @param   vector      A pointer to the `ZyanVector` instance.
  * @param   capacity    Receives the size of the vector.
@@ -703,7 +703,7 @@ ZYCORE_EXPORT ZyanStatus ZyanVectorShrinkToFit(ZyanVector* vector);
 ZYCORE_EXPORT ZyanStatus ZyanVectorGetCapacity(const ZyanVector* vector, ZyanUSize* capacity);
 
 /**
- * @brief   Returns the current size of the vector.
+ * Returns the current size of the vector.
  *
  * @param   vector  A pointer to the `ZyanVector` instance.
  * @param   size    Receives the size of the vector.

--- a/include/Zycore/Zycore.h
+++ b/include/Zycore/Zycore.h
@@ -26,7 +26,7 @@
 
 /**
  * @file
- * @brief   Master include file, including everything else.
+ * Master include file, including everything else.
  */
 
 #ifndef ZYCORE_H
@@ -50,7 +50,7 @@ extern "C" {
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   A macro that defines the zycore version.
+ * A macro that defines the zycore version.
  */
 #define ZYCORE_VERSION (ZyanU64)0x0001000000000000
 
@@ -59,28 +59,28 @@ extern "C" {
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Extracts the major-part of the zycore version.
+ * Extracts the major-part of the zycore version.
  *
  * @param   version The zycore version value
  */
 #define ZYCORE_VERSION_MAJOR(version) (ZyanU16)((version & 0xFFFF000000000000) >> 48)
 
 /**
- * @brief   Extracts the minor-part of the zycore version.
+ * Extracts the minor-part of the zycore version.
  *
  * @param   version The zycore version value
  */
 #define ZYCORE_VERSION_MINOR(version) (ZyanU16)((version & 0x0000FFFF00000000) >> 32)
 
 /**
- * @brief   Extracts the patch-part of the zycore version.
+ * Extracts the patch-part of the zycore version.
  *
  * @param   version The zycore version value
  */
 #define ZYCORE_VERSION_PATCH(version) (ZyanU16)((version & 0x00000000FFFF0000) >> 16)
 
 /**
- * @brief   Extracts the build-part of the zycore version.
+ * Extracts the build-part of the zycore version.
  *
  * @param   version The zycore version value
  */
@@ -93,7 +93,7 @@ extern "C" {
 /* ============================================================================================== */
 
 /**
- * @brief   Returns the zycore version.
+ * Returns the zycore version.
  *
  * @return  The zycore version.
  *

--- a/src/Bitset.c
+++ b/src/Bitset.c
@@ -39,7 +39,7 @@
 /* ============================================================================================== */
 
 /**
- * @brief   Computes the smallest integer value not less than `x`.
+ * Computes the smallest integer value not less than `x`.
  *
  * @param   x   The value.
  *
@@ -49,7 +49,7 @@
     (((x) == ((ZyanU32)(x))) ? (ZyanU32)(x) : ((ZyanU32)(x)) + 1)
 
 /**
- * @brief   Converts bits to bytes.
+ * Converts bits to bytes.
  *
  * @param   x   The value in bits.
  *
@@ -59,7 +59,7 @@
     ZYAN_BITSET_CEIL((x) / 8.0f)
 
 /**
- * @brief   Returns the offset of the given bit.
+ * Returns the offset of the given bit.
  *
  * @param   index   The bit index.
  *
@@ -77,7 +77,7 @@
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Initializes the given `vector` with `count` "zero"-bytes.
+ * Initializes the given `vector` with `count` "zero"-bytes.
  *
  * @param   vector  A pointer to the `ZyanVector` instance.
  * @param   count   The number of bytes.
@@ -150,7 +150,7 @@ ZyanStatus ZyanBitsetInitEx(ZyanBitset* bitset, ZyanUSize count, ZyanAllocator* 
     const ZyanU32 bytes = ZYAN_BITSET_BITS_TO_BYTES(count);
 
     bitset->size = count;
-    ZYAN_CHECK(ZyanVectorInitEx(&bitset->bits, sizeof(ZyanU8), bytes, ZYAN_NULL, allocator, 
+    ZYAN_CHECK(ZyanVectorInitEx(&bitset->bits, sizeof(ZyanU8), bytes, ZYAN_NULL, allocator,
         growth_factor, shrink_threshold));
     ZYAN_CHECK(ZyanBitsetInitVectorElements(&bitset->bits, bytes));
 
@@ -172,7 +172,7 @@ ZyanStatus ZyanBitsetInitBuffer(ZyanBitset* bitset, ZyanUSize count, void* buffe
     }
 
     bitset->size = count;
-    ZYAN_CHECK(ZyanVectorInitCustomBuffer(&bitset->bits, sizeof(ZyanU8), buffer, capacity, 
+    ZYAN_CHECK(ZyanVectorInitCustomBuffer(&bitset->bits, sizeof(ZyanU8), buffer, capacity,
         ZYAN_NULL));
     ZYAN_CHECK(ZyanBitsetInitVectorElements(&bitset->bits, bytes));
 
@@ -661,7 +661,7 @@ ZyanStatus ZyanBitsetNone(const ZyanBitset* bitset)
 //    }
 //
 //    // TODO:
-//    
+//
 //    return ZYAN_STATUS_SUCCESS;
 //}
 

--- a/src/Format.c
+++ b/src/Format.c
@@ -70,7 +70,7 @@ static const ZyanStringView STR_SUB = ZYAN_DEFINE_STRING_VIEW("-");
 /* ============================================================================================== */
 
 /**
- * @brief   Writes a terminating '\0' character at the end of the string data.
+ * Writes a terminating '\0' character at the end of the string data.
  */
 #define ZYCORE_STRING_NULLTERMINATE(string) \
       *(char*)((ZyanU8*)(string)->vector.data + (string)->vector.size - 1) = '\0';

--- a/src/List.c
+++ b/src/List.c
@@ -32,10 +32,10 @@
 /* ============================================================================================== */
 
 /**
- * @brief   Returns a pointer to the data of the given `node`.
- * 
+ * Returns a pointer to the data of the given `node`.
+ *
  * @param   node    A pointer to the `ZyanNodeData` struct.
- * 
+ *
  * @return  A pointer to the data of the given `node`.
  */
 #define ZYCORE_LIST_GET_NODE_DATA(node) \
@@ -50,11 +50,11 @@
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Allocates memory for a new list node.
- * 
+ * Allocates memory for a new list node.
+ *
  * @param   list    A pointer to the `ZyanList` instance.
  * @param   node    Receives a pointer to the new `ZyanListNode` struct.
- * 
+ *
  * @return  A zyan status code.
  */
 static ZyanStatus ZyanListAllocateNode(ZyanList* list, ZyanListNode** node)
@@ -66,7 +66,7 @@ static ZyanStatus ZyanListAllocateNode(ZyanList* list, ZyanListNode** node)
     if (is_dynamic)
     {
         ZYAN_ASSERT(list->allocator->allocate);
-        ZYAN_CHECK(list->allocator->allocate(list->allocator, (void**)node, 
+        ZYAN_CHECK(list->allocator->allocate(list->allocator, (void**)node,
             sizeof(ZyanListNode) + list->element_size, 1));
     } else
     {
@@ -90,11 +90,11 @@ static ZyanStatus ZyanListAllocateNode(ZyanList* list, ZyanListNode** node)
 }
 
 /**
- * @brief   Frees memory of a node.
- * 
+ * Frees memory of a node.
+ *
  * @param   list    A pointer to the `ZyanList` instance.
  * @param   node    A pointer to the `ZyanListNode` struct.
- * 
+ *
  * @return  A zyan status code.
  */
 static ZyanStatus ZyanListDeallocateNode(ZyanList* list, ZyanListNode* node)
@@ -106,7 +106,7 @@ static ZyanStatus ZyanListDeallocateNode(ZyanList* list, ZyanListNode* node)
     if (is_dynamic)
     {
         ZYAN_ASSERT(list->allocator->deallocate);
-        ZYAN_CHECK(list->allocator->deallocate(list->allocator, (void*)node, 
+        ZYAN_CHECK(list->allocator->deallocate(list->allocator, (void*)node,
             sizeof(ZyanListNode) + list->element_size, 1));
     } else
     {
@@ -137,7 +137,7 @@ ZYAN_REQUIRES_LIBC ZyanStatus ZyanListInit(ZyanList* list, ZyanUSize element_siz
 
 #endif // ZYAN_NO_LIBC
 
-ZyanStatus ZyanListInitEx(ZyanList* list, ZyanUSize element_size, ZyanMemberProcedure destructor, 
+ZyanStatus ZyanListInitEx(ZyanList* list, ZyanUSize element_size, ZyanMemberProcedure destructor,
     ZyanAllocator* allocator)
 {
     if (!list || !element_size || !allocator)
@@ -176,7 +176,7 @@ ZyanStatus ZyanListInitCustomBuffer(ZyanList* list, ZyanUSize element_size,
     list->capacity     = capacity;
     list->first_unused = ZYAN_NULL;
 
-    return ZYAN_STATUS_SUCCESS;    
+    return ZYAN_STATUS_SUCCESS;
 }
 
 ZyanStatus ZyanListDestroy(ZyanList* list)
@@ -201,14 +201,14 @@ ZyanStatus ZyanListDestroy(ZyanList* list)
 
         if (is_dynamic)
         {
-            ZYAN_CHECK(list->allocator->deallocate(list->allocator, node, 
-                sizeof(ZyanListNode) + list->element_size, 1));    
+            ZYAN_CHECK(list->allocator->deallocate(list->allocator, node,
+                sizeof(ZyanListNode) + list->element_size, 1));
         }
 
         node = next;
     }
 
-    return ZYAN_STATUS_SUCCESS;    
+    return ZYAN_STATUS_SUCCESS;
 }
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -242,7 +242,7 @@ ZyanStatus ZyanListGetTailNode(const ZyanList* list, const ZyanListNode** node)
 
     *node = list->tail;
 
-    return ZYAN_STATUS_SUCCESS;    
+    return ZYAN_STATUS_SUCCESS;
 }
 
 ZyanStatus ZyanListGetPrevNode(const ZyanListNode** node)
@@ -254,7 +254,7 @@ ZyanStatus ZyanListGetPrevNode(const ZyanListNode** node)
 
     *node = (*node)->prev;
 
-    return ZYAN_STATUS_SUCCESS;    
+    return ZYAN_STATUS_SUCCESS;
 }
 
 ZyanStatus ZyanListGetNextNode(const ZyanListNode** node)
@@ -266,7 +266,7 @@ ZyanStatus ZyanListGetNextNode(const ZyanListNode** node)
 
     *node = (*node)->next;
 
-    return ZYAN_STATUS_SUCCESS;    
+    return ZYAN_STATUS_SUCCESS;
 }
 
 const void* ZyanListGetNodeData(const ZyanListNode* node)
@@ -276,7 +276,7 @@ const void* ZyanListGetNodeData(const ZyanListNode* node)
         return ZYAN_NULL;
     }
 
-    return (const void*)ZYCORE_LIST_GET_NODE_DATA(node);    
+    return (const void*)ZYCORE_LIST_GET_NODE_DATA(node);
 }
 
 ZyanStatus ZyanListGetNodeDataEx(const ZyanListNode* node, const void** value)
@@ -288,7 +288,7 @@ ZyanStatus ZyanListGetNodeDataEx(const ZyanListNode* node, const void** value)
 
     *value = (const void*)ZYCORE_LIST_GET_NODE_DATA(node);
 
-    return ZYAN_STATUS_SUCCESS;    
+    return ZYAN_STATUS_SUCCESS;
 }
 
 void* ZyanListGetNodeDataMutable(const ZyanListNode* node)
@@ -298,7 +298,7 @@ void* ZyanListGetNodeDataMutable(const ZyanListNode* node)
         return ZYAN_NULL;
     }
 
-    return ZYCORE_LIST_GET_NODE_DATA(node);     
+    return ZYCORE_LIST_GET_NODE_DATA(node);
 }
 
 ZyanStatus ZyanListGetNodeDataMutableEx(const ZyanListNode* node, void** value)
@@ -310,7 +310,7 @@ ZyanStatus ZyanListGetNodeDataMutableEx(const ZyanListNode* node, void** value)
 
     *value = ZYCORE_LIST_GET_NODE_DATA(node);
 
-    return ZYAN_STATUS_SUCCESS;     
+    return ZYAN_STATUS_SUCCESS;
 }
 
 ZyanStatus ZyanListSetNodeData(const ZyanList* list, const ZyanListNode* node, const void* value)
@@ -388,7 +388,7 @@ ZyanStatus ZyanListPushFront(ZyanList* list, const void* item)
     }
     ++list->size;
 
-    return ZYAN_STATUS_SUCCESS;    
+    return ZYAN_STATUS_SUCCESS;
 }
 
 ZyanStatus ZyanListEmplaceBack(ZyanList* list, void** item, ZyanMemberFunction constructor)
@@ -452,7 +452,7 @@ ZyanStatus ZyanListEmplaceFront(ZyanList* list, void** item, ZyanMemberFunction 
     }
     ++list->size;
 
-    return ZYAN_STATUS_SUCCESS;    
+    return ZYAN_STATUS_SUCCESS;
 }
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -520,7 +520,7 @@ ZyanStatus ZyanListPopFront(ZyanList* list)
     }
     --list->size;
 
-    return ZyanListDeallocateNode(list, node);    
+    return ZyanListDeallocateNode(list, node);
 }
 
 ZyanStatus ZyanListRemove(ZyanList* list, const ZyanListNode* node)
@@ -535,7 +535,7 @@ ZyanStatus ZyanListRemoveRange(ZyanList* list, const ZyanListNode* first, const 
     ZYAN_UNUSED(list);
     ZYAN_UNUSED(first);
     ZYAN_UNUSED(last);
-    return ZYAN_STATUS_SUCCESS;    
+    return ZYAN_STATUS_SUCCESS;
 }
 
 ZyanStatus ZyanListClear(ZyanList* list)
@@ -584,8 +584,8 @@ ZyanStatus ZyanListResizeEx(ZyanList* list, ZyanUSize size, const void* initiali
 
             if (is_dynamic)
             {
-                ZYAN_CHECK(list->allocator->deallocate(list->allocator, node, 
-                    sizeof(ZyanListNode) + list->element_size, 1));    
+                ZYAN_CHECK(list->allocator->deallocate(list->allocator, node,
+                    sizeof(ZyanListNode) + list->element_size, 1));
             }
 
             node = next;
@@ -610,9 +610,9 @@ ZyanStatus ZyanListResizeEx(ZyanList* list, ZyanUSize size, const void* initiali
 
             if (initializer)
             {
-                ZYAN_MEMCPY(ZYCORE_LIST_GET_NODE_DATA(node), initializer, list->element_size);   
+                ZYAN_MEMCPY(ZYCORE_LIST_GET_NODE_DATA(node), initializer, list->element_size);
             }
-            
+
             if (!list->head)
             {
                 list->head = node;
@@ -649,7 +649,7 @@ ZyanStatus ZyanListResizeEx(ZyanList* list, ZyanUSize size, const void* initiali
         list->size = size;
     }
 
-    return ZYAN_STATUS_SUCCESS;    
+    return ZYAN_STATUS_SUCCESS;
 }
 
 /* ---------------------------------------------------------------------------------------------- */

--- a/src/String.c
+++ b/src/String.c
@@ -32,13 +32,13 @@
 /* ============================================================================================== */
 
 /**
- * @brief   Writes a terminating '\0' character at the end of the string data.
+ * Writes a terminating '\0' character at the end of the string data.
  */
 #define ZYCORE_STRING_NULLTERMINATE(string) \
       *(char*)((ZyanU8*)(string)->vector.data + (string)->vector.size - 1) = '\0';
 
 /**
- * @brief   Checks for a terminating '\0' character at the end of the string data.
+ * Checks for a terminating '\0' character at the end of the string data.
  */
 #define ZYCORE_STRING_ASSERT_NULLTERMINATION(string) \
       ZYAN_ASSERT(*(char*)((ZyanU8*)(string)->vector.data + (string)->vector.size - 1) == '\0');
@@ -91,7 +91,7 @@ ZyanStatus ZyanStringInitCustomBuffer(ZyanString* string, char* buffer, ZyanUSiz
     }
 
     string->flags = ZYAN_STRING_HAS_FIXED_CAPACITY;
-    ZYAN_CHECK(ZyanVectorInitCustomBuffer(&string->vector, sizeof(char), (void*)buffer, capacity, 
+    ZYAN_CHECK(ZyanVectorInitCustomBuffer(&string->vector, sizeof(char), (void*)buffer, capacity,
         ZYAN_NULL));
     ZYAN_ASSERT(string->vector.capacity == capacity);
     // Some of the string code relies on `sizeof(char) == 1`

--- a/src/Vector.c
+++ b/src/Vector.c
@@ -32,7 +32,7 @@
 /* ============================================================================================== */
 
 /**
- * @brief   Checks, if the passed vector should grow.
+ * Checks, if the passed vector should grow.
  *
  * @param   size        The desired size of the vector.
  * @param   capacity    The current capacity of the vector.
@@ -43,7 +43,7 @@
     ((size) > (capacity))
 
 /**
- * @brief   Checks, if the passed vector should shrink.
+ * Checks, if the passed vector should shrink.
  *
  * @param   size        The desired size of the vector.
  * @param   capacity    The current capacity of the vector.
@@ -55,7 +55,7 @@
     ((size) < (capacity) * (threshold))
 
 /**
- * @brief   Returns the offset of the element at the given `index`.
+ * Returns the offset of the element at the given `index`.
  *
  * @param   vector  A pointer to the `ZyanVector` instance.
  * @param   index   The element index.
@@ -74,7 +74,7 @@
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
- * @brief   Reallocates the internal buffer of the vector.
+ * Reallocates the internal buffer of the vector.
  *
  * @param   vector      A pointer to the `ZyanVector` instance.
  * @param   capacity    The new capacity.
@@ -119,8 +119,8 @@ static ZyanStatus ZyanVectorReallocate(ZyanVector* vector, ZyanUSize capacity)
 }
 
 /**
- * @brief   Shifts all elements starting at the specified `index` by the amount of `count` to the
- *          left.
+ * Shifts all elements starting at the specified `index` by the amount of
+ * `count` to the left.
  *
  * @param   vector  A pointer to the `ZyanVector` instance.
  * @param   index   The start index.
@@ -145,8 +145,8 @@ static ZyanStatus ZyanVectorShiftLeft(ZyanVector* vector, ZyanUSize index, ZyanU
 }
 
 /**
- * @brief   Shifts all elements starting at the specified `index` by the amount of `count` to the
- *          right.
+ * Shifts all elements starting at the specified `index` by the amount of
+ * `count` to the right.
  *
  * @param   vector  A pointer to the `ZyanVector` instance.
  * @param   index   The start index.
@@ -192,7 +192,7 @@ ZyanStatus ZyanVectorInit(ZyanVector* vector, ZyanUSize element_size, ZyanUSize 
 #endif // ZYAN_NO_LIBC
 
 ZyanStatus ZyanVectorInitEx(ZyanVector* vector, ZyanUSize element_size, ZyanUSize capacity,
-    ZyanMemberProcedure destructor, ZyanAllocator* allocator, float growth_factor, 
+    ZyanMemberProcedure destructor, ZyanAllocator* allocator, float growth_factor,
     float shrink_threshold)
 {
     if (!vector || !element_size || !allocator || (growth_factor < 1.0f) ||
@@ -291,7 +291,7 @@ ZyanStatus ZyanVectorDuplicateEx(ZyanVector* destination, const ZyanVector* sour
     const ZyanUSize len = source->size;
 
     capacity = ZYAN_MAX(capacity, len);
-    ZYAN_CHECK(ZyanVectorInitEx(destination, source->element_size, capacity, source->destructor, 
+    ZYAN_CHECK(ZyanVectorInitEx(destination, source->element_size, capacity, source->destructor,
         allocator, growth_factor, shrink_threshold));
     ZYAN_ASSERT(destination->capacity >= len);
 
@@ -316,7 +316,7 @@ ZyanStatus ZyanVectorDuplicateCustomBuffer(ZyanVector* destination, const ZyanVe
         return ZYAN_STATUS_INSUFFICIENT_BUFFER_SIZE;
     }
 
-    ZYAN_CHECK(ZyanVectorInitCustomBuffer(destination, source->element_size, buffer, capacity, 
+    ZYAN_CHECK(ZyanVectorInitCustomBuffer(destination, source->element_size, buffer, capacity,
         source->destructor));
     ZYAN_ASSERT(destination->capacity >= len);
 
@@ -768,7 +768,7 @@ ZyanStatus ZyanVectorResizeEx(ZyanVector* vector, ZyanUSize size, const void* in
         for (ZyanUSize i = size; i < vector->size; ++i)
         {
             vector->destructor(ZYCORE_VECTOR_OFFSET(vector, i));
-        }       
+        }
     }
 
     if (ZYCORE_VECTOR_SHOULD_GROW(size, vector->capacity) ||
@@ -782,7 +782,7 @@ ZyanStatus ZyanVectorResizeEx(ZyanVector* vector, ZyanUSize size, const void* in
         for (ZyanUSize i = vector->size; i < size; ++i)
         {
             ZYAN_MEMCPY(ZYCORE_VECTOR_OFFSET(vector, i), initializer, vector->element_size);
-        }       
+        }
     }
 
     vector->size = size;


### PR DESCRIPTION
In private conversation it was decided that we want to switch away from the unnecessarily verbose explicit `@brief` doxygen syntax and instead use auto-brief.

This PR implements this change. All occurrences of `@brief` were replaced automatically and then, after review of the changes, indentation of the next line(s) were fixed manually.

Things to look out for in review:
- Incorrect indentation of the next line after line where `@brief` was removed
- Parameter documentations that were previously incorrectly created with `@brief` instead of `@param` and now don't have any directive at all

While at it, any trialing whitespace in files was stripped as well.

Priority is high because this will likely clash with any possible other PR and require ugly rebases.