### PR TITLE
Replace fallthrough attribute to __fallthrough__

### DIFF
--- a/include/Zycore/Defines.h
+++ b/include/Zycore/Defines.h
@@ -264,7 +264,7 @@
  * Intentional fallthrough.
  */
 #if defined(ZYAN_GCC) && __GNUC__ >= 7
-#   define ZYAN_FALLTHROUGH __attribute__((fallthrough))
+#   define ZYAN_FALLTHROUGH __attribute__((__fallthrough__))
 #else
 #   define ZYAN_FALLTHROUGH
 #endif


### PR DESCRIPTION
Linux kernel 5.4, introduce a new fallthrough macro, which cause compilation failure of zycore-c.
(https://github.com/torvalds/linux/commit/294f69e662d1570703e9b56e95be37a9fd3afba5)