### PR TITLE
Fix cmake config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,7 @@ set_target_properties("Zycore" PROPERTIES LINKER_LANGUAGE C)
 target_include_directories("Zycore"
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/Zycore>
     PRIVATE "src")
 target_compile_definitions("Zycore" PRIVATE "_CRT_SECURE_NO_WARNINGS" "ZYCORE_EXPORTS")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,9 @@ endif ()
 
 set_target_properties("Zycore" PROPERTIES LINKER_LANGUAGE C)
 target_include_directories("Zycore"
-    PUBLIC "include" ${PROJECT_BINARY_DIR}
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/Zycore>
     PRIVATE "src")
 target_compile_definitions("Zycore" PRIVATE "_CRT_SECURE_NO_WARNINGS" "ZYCORE_EXPORTS")
 zyan_set_common_flags("Zycore")
@@ -195,17 +197,26 @@ endif ()
 
 configure_package_config_file(cmake/zycore-config.cmake.in
     "${CMAKE_CURRENT_BINARY_DIR}/zycore-config.cmake"
-    INSTALL_DESTINATION "${CMAKE_INSTALL_PREFIX}/cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/zycore"
+)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/zycore-config-version.cmake"
+    COMPATIBILITY SameMajorVersion
 )
 install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/zycore-config.cmake"
-    DESTINATION "${CMAKE_INSTALL_PREFIX}/cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/zycore-config-version.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/zycore"
 )
 
 install(TARGETS "Zycore"
+    EXPORT "zycore-targets"
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(EXPORT "zycore-targets"
+    NAMESPACE "Zycore::"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/zycore")
 install(FILES
     "${PROJECT_BINARY_DIR}/ZycoreExportConfig.h"
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")

--- a/cmake/zycore-config.cmake.in
+++ b/cmake/zycore-config.cmake.in
@@ -2,6 +2,11 @@ set(zycore_VERSION @PROJECT_VERSION@)
 
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND NOT @ZYAN_NO_LIBC@)
+    find_dependency(Threads)
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/zycore-targets.cmake")
 
 set_and_check(zycore_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")

--- a/cmake/zycore-config.cmake.in
+++ b/cmake/zycore-config.cmake.in
@@ -2,6 +2,8 @@ set(zycore_VERSION @PROJECT_VERSION@)
 
 @PACKAGE_INIT@
 
+include("${CMAKE_CURRENT_LIST_DIR}/zycore-targets.cmake")
+
 set_and_check(zycore_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")
 set_and_check(zycore_LIB_DIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@")
 


### PR DESCRIPTION
The current `config.cmake` file is almost empty and is installed in the wrong directory.
Also add the `config-version.cmake` file.