### PR TITLE
build(cmake): export and install zyan_* functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,50 +89,8 @@ if (ZYCORE_BUILD_TESTS)
         EXCLUDE_FROM_ALL)
 endif ()
 
-# =============================================================================================== #
-# Exported functions                                                                              #
-# =============================================================================================== #
-
-function (zyan_set_common_flags target)
-    if (NOT MSVC)
-        target_compile_options("${target}" PRIVATE "-std=c99")
-    endif ()
-
-    if (ZYAN_DEV_MODE)
-        # If in developer mode, be pedantic.
-        if (MSVC)
-            target_compile_options("${target}" PUBLIC "/WX" "/W4")
-        else ()
-            target_compile_options("${target}" PUBLIC "-Wall" "-pedantic" "-Wextra" "-Werror")
-        endif ()
-    endif ()
-endfunction ()
-
-function (zyan_set_source_group target)
-    if (ZYAN_DEV_MODE)
-        if (((CMAKE_MAJOR_VERSION GREATER 3) OR (CMAKE_MAJOR_VERSION EQUAL 3)) AND
-            ((CMAKE_MINOR_VERSION GREATER 8) OR (CMAKE_MINOR_VERSION EQUAL 8)))
-            # Mirror directory structure in project files
-            get_property("TARGET_SOURCE_FILES" TARGET "${target}" PROPERTY SOURCES)
-            source_group(TREE "${CMAKE_CURRENT_LIST_DIR}" FILES ${TARGET_SOURCE_FILES})
-        endif ()
-    endif ()
-endfunction ()
-
-function (zyan_maybe_enable_wpo target)
-    if (ZYAN_WHOLE_PROGRAM_OPTIMIZATION AND MSVC)
-        set_target_properties("${target}" PROPERTIES COMPILE_FLAGS "/GL")
-        set_target_properties("${target}" PROPERTIES LINK_FLAGS_RELEASE "/LTCG")
-    endif ()
-endfunction ()
-
-function (zyan_maybe_enable_wpo_for_lib target)
-    if (ZYAN_WHOLE_PROGRAM_OPTIMIZATION AND MSVC)
-        set_target_properties("${target}" PROPERTIES COMPILE_FLAGS "/GL")
-        set_target_properties("${target}" PROPERTIES LINK_FLAGS_RELEASE "/LTCG")
-        set_target_properties("${target}" PROPERTIES STATIC_LIBRARY_FLAGS_RELEASE "/LTCG")
-    endif ()
-endfunction ()
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(zyan-functions)
 
 # =============================================================================================== #
 # Library configuration                                                                           #
@@ -226,16 +184,13 @@ write_basic_package_version_file(
     COMPATIBILITY SameMajorVersion
 )
 install(FILES
+    "cmake/zyan-functions.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/zycore-config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/zycore-config-version.cmake"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/zycore"
 )
 
-install(TARGETS "Zycore"
-    EXPORT "zycore-targets"
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS "Zycore" EXPORT "zycore-targets")
 install(EXPORT "zycore-targets"
     NAMESPACE "Zycore::"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/zycore")

--- a/cmake/zyan-functions.cmake
+++ b/cmake/zyan-functions.cmake
@@ -1,0 +1,44 @@
+# =============================================================================================== #
+# Exported functions                                                                              #
+# =============================================================================================== #
+
+function (zyan_set_common_flags target)
+    if (NOT MSVC)
+        target_compile_options("${target}" PRIVATE "-std=c99")
+    endif ()
+
+    if (ZYAN_DEV_MODE)
+        # If in developer mode, be pedantic.
+        if (MSVC)
+            target_compile_options("${target}" PUBLIC "/WX" "/W4")
+        else ()
+            target_compile_options("${target}" PUBLIC "-Wall" "-pedantic" "-Wextra" "-Werror")
+        endif ()
+    endif ()
+endfunction ()
+
+function (zyan_set_source_group target)
+    if (ZYAN_DEV_MODE)
+        if (((CMAKE_MAJOR_VERSION GREATER 3) OR (CMAKE_MAJOR_VERSION EQUAL 3)) AND
+            ((CMAKE_MINOR_VERSION GREATER 8) OR (CMAKE_MINOR_VERSION EQUAL 8)))
+            # Mirror directory structure in project files
+            get_property("TARGET_SOURCE_FILES" TARGET "${target}" PROPERTY SOURCES)
+            source_group(TREE "${CMAKE_CURRENT_LIST_DIR}" FILES ${TARGET_SOURCE_FILES})
+        endif ()
+    endif ()
+endfunction ()
+
+function (zyan_maybe_enable_wpo target)
+    if (ZYAN_WHOLE_PROGRAM_OPTIMIZATION AND MSVC)
+        set_target_properties("${target}" PROPERTIES COMPILE_FLAGS "/GL")
+        set_target_properties("${target}" PROPERTIES LINK_FLAGS_RELEASE "/LTCG")
+    endif ()
+endfunction ()
+
+function (zyan_maybe_enable_wpo_for_lib target)
+    if (ZYAN_WHOLE_PROGRAM_OPTIMIZATION AND MSVC)
+        set_target_properties("${target}" PROPERTIES COMPILE_FLAGS "/GL")
+        set_target_properties("${target}" PROPERTIES LINK_FLAGS_RELEASE "/LTCG")
+        set_target_properties("${target}" PROPERTIES STATIC_LIBRARY_FLAGS_RELEASE "/LTCG")
+    endif ()
+endfunction ()

--- a/cmake/zycore-config.cmake.in
+++ b/cmake/zycore-config.cmake.in
@@ -7,6 +7,8 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND NOT @ZYAN_NO_LIBC@)
     find_dependency(Threads)
 endif()
 
+include("${CMAKE_CURRENT_LIST_DIR}/zyan-functions.cmake")
+
 include("${CMAKE_CURRENT_LIST_DIR}/zycore-targets.cmake")
 
 set_and_check(zycore_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")


### PR DESCRIPTION
Now when calling `find_package(Zycore)` users will be able to use the `zyan` functions.

This would make it possible to use `find_package(Zycore)` to find and use the system Zycore library in Zydis. Before this change, if instead of compiling Zycore with `add_subdirectory()` you used `find_package(Zycore)`, the build failed, because functions like `zyan_set_common_flags()` were not imported.

I also removed `ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}` etc from `install(TARGETS ...)` because they are already [set by default](https://cmake.org/cmake/help/latest/command/install.html#targets) 