### PR TITLE
Tests tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ if (TARGET Zycore)
     return()
 endif ()
 
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
 project(Zycore VERSION 1.1.0.0 LANGUAGES C CXX)
 
@@ -234,19 +234,21 @@ endif ()
 
 function (zyan_add_test test)
     add_executable("Test${test}" "tests/${test}.cpp")
-
-    if (NOT MSVC)
-        target_compile_options("Test${test}" PRIVATE "-std=c++17")
-    endif ()
-
-    target_link_libraries("Test${test}" "Zycore")
-    target_link_libraries("Test${test}" "gtest")
-    set_target_properties("Test${test}" PROPERTIES FOLDER "Tests")
+    target_link_libraries("Test${test}" "Zycore" "gtest")
+    set_target_properties("Test${test}" PROPERTIES
+        LANGUAGE CXX
+        CXX_STANDARD 17
+        CXX_EXTENSIONS OFF
+        CXX_STANDARD_REQUIRED ON
+        FOLDER "Tests"
+    )
     target_compile_definitions("Test${test}" PRIVATE "_CRT_SECURE_NO_WARNINGS")
     zyan_maybe_enable_wpo("Test${test}")
+    add_test("${test}" "Test${test}")
 endfunction ()
 
 if (ZYCORE_BUILD_TESTS)
+    enable_testing()
     zyan_add_test("String")
     zyan_add_test("Vector")
     zyan_add_test("ArgParse")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,31 +63,42 @@ endif ()
 # GoogleTest                                                                                      #
 # =============================================================================================== #
 
-# Download and unpack googletest
+# Search for GoogleTest, and fallback to downloading it if not found
 if (ZYCORE_BUILD_TESTS)
-    if (NOT DEFINED ZYCORE_DOWNLOADED_GTEST)
-        configure_file("CMakeLists.txt.in" "${CMAKE_BINARY_DIR}/gtest/download/CMakeLists.txt")
-        execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-            RESULT_VARIABLE result
-            WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/gtest/download")
-        if (result)
-            message(FATAL_ERROR "CMake step for googletest failed: ${result}")
-        endif()
-        execute_process(COMMAND ${CMAKE_COMMAND} --build .
-            RESULT_VARIABLE result
-            WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/gtest/download")
-        if (result)
-            message(FATAL_ERROR "Build step for googletest failed: ${result}")
-        endif()
+    find_package(GTest QUIET)
+    if (GTest_FOUND)
+        # CMake 3.20 and upstream GTestConfig.cmake
+        if (TARGET GTest::gtest)
+            add_library(gtest ALIAS GTest::gtest)
+        # Older FindGTest
+        else ()
+            add_library(gtest ALIAS GTest::GTest)
+        endif ()
+    else ()
+        if (NOT DEFINED ZYCORE_DOWNLOADED_GTEST)
+            configure_file("CMakeLists.txt.in" "${CMAKE_BINARY_DIR}/gtest/download/CMakeLists.txt")
+            execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+                RESULT_VARIABLE result
+                WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/gtest/download")
+            if (result)
+                message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+            endif()
+            execute_process(COMMAND ${CMAKE_COMMAND} --build .
+                RESULT_VARIABLE result
+                WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/gtest/download")
+            if (result)
+                message(FATAL_ERROR "Build step for googletest failed: ${result}")
+            endif()
 
-        set(ZYCORE_DOWNLOADED_GTEST TRUE CACHE BOOL "")
-        mark_as_advanced(ZYCORE_DOWNLOADED_GTEST)
-    endif ()
+            set(ZYCORE_DOWNLOADED_GTEST TRUE CACHE BOOL "")
+            mark_as_advanced(ZYCORE_DOWNLOADED_GTEST)
+        endif ()
 
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
     add_subdirectory("${CMAKE_BINARY_DIR}/gtest/src" "${CMAKE_BINARY_DIR}/gtest/build"
         EXCLUDE_FROM_ALL)
+    endif ()
 endif ()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,7 @@ zyan_set_source_group("Zycore")
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND NOT ZYAN_NO_LIBC)
     target_compile_definitions("Zycore" PRIVATE "_GNU_SOURCE")
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads REQUIRED)
     target_link_libraries("Zycore" Threads::Threads)
 endif ()


### PR DESCRIPTION
The changes are not that big, but I decided to split them in multiple commits because every one of them does a different thing. They are all related though, so I prepared a single PR. Here's their description (from the commit messages):

### test: make tests runnable with ctest

This helps with automated testing, as tests can be ran with `ctest` or by "building" the target `test`

I also changed the way the C++ standard version is handled; the tests require C++17, and this was previously accomplished by manually passing the `-std=c++17` flag, while the "CMake way" of doing this is to set the `CXX_STANDARD` property. Unfortunately the value `17` of the property was only added in CMake 3.8, so when using older CMake versions the flag is still passed manually. I've also set the `CXX_EXTENSIONS` and `CXX_STANDARD_REQUIRED` to false and true, respectively, to ensure that `-std=c++17` gets passed instead of `-std=gnu++17` on GCC-like compilers and that CMake doesn't fallback to older standards versions when the requested standard is not available.

### build: use system GTest when available

This reduces compile times and allows tests to be ran in environments without internet access (e.g. when building a Debian package).

CMake will look for an installed copy of GoogleTest on the system, and will use it if found, and will fallback to download and unpack it otherwise.

There are a lot of checks involved since CMake changed the way FindGTest works in newer CMake versions, and they are needed to ensure 3.1 compatibility.

### build: use -pthread when possible

Using -pthread is the "right way" of enabling threading support in GCC and similar, and this can accomplished with the THREADS_PREFER_PTHREAD_FLAG option. Its use is also recommended by the CMake devs, see [cmake.org/cmake/help/latest/module/FindThreads.html](https://cmake.org/cmake/help/latest/module/FindThreads.html#variable:THREADS_PREFER_PTHREAD_FLAG)

More words than code changes :)