### PR TITLE
add basic WebAssembly support

### DIFF
--- a/include/Zycore/Defines.h
+++ b/include/Zycore/Defines.h
@@ -85,6 +85,9 @@
 #   define ZYAN_WINDOWS
 #elif defined(__EMSCRIPTEN__)
 #   define ZYAN_EMSCRIPTEN
+#elif defined(__wasi__) || defined(__WASI__)
+// via: https://reviews.llvm.org/D57155
+#   define ZYAN_WASI
 #elif defined(__APPLE__)
 #   define ZYAN_APPLE
 #   define ZYAN_POSIX
@@ -131,8 +134,8 @@
 #   define ZYAN_AARCH64
 #elif defined(_M_ARM) || defined(_M_ARMT) || defined(__arm__) || defined(__thumb__)
 #   define ZYAN_ARM
-#elif defined(__EMSCRIPTEN__)
-    // Nothing to do, `ZYAN_EMSCRIPTEN` is both platform and arch macro for this one.
+#elif defined(__EMSCRIPTEN__) || defined(__wasm__) || defined(__WASM__)
+#   define ZYAN_WASM
 #else
 #   error "Unsupported architecture detected"
 #endif

--- a/src/Format.c
+++ b/src/Format.c
@@ -179,7 +179,7 @@ ZyanStatus ZyanStringAppendDecU64(ZyanString* string, ZyanU64 value, ZyanU8 padd
 /* Hexadecimal                                                                                    */
 /* ---------------------------------------------------------------------------------------------- */
 
-#if defined(ZYAN_X86) || defined(ZYAN_ARM) || defined(ZYAN_EMSCRIPTEN)
+#if defined(ZYAN_X86) || defined(ZYAN_ARM) || defined(ZYAN_EMSCRIPTEN) || defined(ZYAN_WASM)
 ZyanStatus ZyanStringAppendHexU32(ZyanString* string, ZyanU32 value, ZyanU8 padding_length,
     ZyanBool uppercase)
 {

--- a/src/Format.c
+++ b/src/Format.c
@@ -83,7 +83,7 @@ static const ZyanStringView STR_SUB = ZYAN_DEFINE_STRING_VIEW("-");
 /* Decimal                                                                                        */
 /* ---------------------------------------------------------------------------------------------- */
 
-#if defined(ZYAN_X86) || defined(ZYAN_ARM) || defined(ZYAN_EMSCRIPTEN)
+#if defined(ZYAN_X86) || defined(ZYAN_ARM) || defined(ZYAN_EMSCRIPTEN) || defined(ZYAN_WASM)
 ZyanStatus ZyanStringAppendDecU32(ZyanString* string, ZyanU32 value, ZyanU8 padding_length)
 {
     if (!string)


### PR DESCRIPTION
 This PR does two things to add basic support for WebAssembly builds:
  1. detect WebAssembly architecture (and WASI platform), and
  2. invoke appropriate formatters for wasm, which is sort-of a 32-bit architecture

The motivation is to use Zydis in a library compiled to WebAssembly. I'm assuming `ZYAN_NO_LIBC` will be sufficient; therefore, I didn't implement any of the platform interfaces for WASI (such as sync, threading, or memory).