### PR TITLE
Get rid of CMake export headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
 project(Zycore VERSION 1.1.0.0 LANGUAGES C CXX)
 
-include(GenerateExportHeader)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
@@ -112,22 +111,23 @@ if (ZYCORE_BUILD_SHARED_LIB)
     add_library("Zycore" SHARED)
 else ()
     add_library("Zycore" STATIC)
+    target_compile_definitions("Zycore" PUBLIC "ZYCORE_STATIC_BUILD")
 endif ()
 
 set_target_properties("Zycore" PROPERTIES
     LINKER_LANGUAGE C
-    VERSION ${Zycore_VERSION}
-    SOVERSION ${Zycore_VERSION_MAJOR}.${Zycore_VERSION_MINOR})
+    VERSION "${Zycore_VERSION}"
+    SOVERSION "${Zycore_VERSION_MAJOR}.${Zycore_VERSION_MINOR}"
+    DEFINE_SYMBOL "ZYCORE_SHOULD_EXPORT")
 target_include_directories("Zycore"
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     PRIVATE "src")
-target_compile_definitions("Zycore" PRIVATE "_CRT_SECURE_NO_WARNINGS" "ZYCORE_EXPORTS")
+target_compile_definitions("Zycore" PRIVATE "_CRT_SECURE_NO_WARNINGS")
 zyan_set_common_flags("Zycore")
 zyan_maybe_enable_wpo_for_lib("Zycore")
-generate_export_header("Zycore" BASE_NAME "ZYCORE" EXPORT_FILE_NAME "ZycoreExportConfig.h")
 
 if (ZYAN_NO_LIBC)
     target_compile_definitions("Zycore" PUBLIC "ZYAN_NO_LIBC")
@@ -207,9 +207,6 @@ install(TARGETS "Zycore" EXPORT "zycore-targets")
 install(EXPORT "zycore-targets"
     NAMESPACE "Zycore::"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/zycore")
-install(FILES
-    "${PROJECT_BINARY_DIR}/ZycoreExportConfig.h"
-    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 install(DIRECTORY "include/" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # =============================================================================================== #

--- a/include/Zycore/API/Memory.h
+++ b/include/Zycore/API/Memory.h
@@ -32,7 +32,6 @@
 #ifndef ZYCORE_API_MEMORY_H
 #define ZYCORE_API_MEMORY_H
 
-#include <ZycoreExportConfig.h>
 #include <Zycore/Defines.h>
 #include <Zycore/Status.h>
 #include <Zycore/Types.h>

--- a/include/Zycore/API/Process.h
+++ b/include/Zycore/API/Process.h
@@ -32,7 +32,6 @@
 #ifndef ZYCORE_API_PROCESS_H
 #define ZYCORE_API_PROCESS_H
 
-#include <ZycoreExportConfig.h>
 #include <Zycore/Status.h>
 #include <Zycore/Types.h>
 

--- a/include/Zycore/API/Synchronization.h
+++ b/include/Zycore/API/Synchronization.h
@@ -32,7 +32,6 @@
 #ifndef ZYCORE_API_SYNCHRONIZATION_H
 #define ZYCORE_API_SYNCHRONIZATION_H
 
-#include <ZycoreExportConfig.h>
 #include <Zycore/Defines.h>
 #include <Zycore/Status.h>
 

--- a/include/Zycore/API/Terminal.h
+++ b/include/Zycore/API/Terminal.h
@@ -32,7 +32,6 @@
 #ifndef ZYCORE_API_TERMINAL_H
 #define ZYCORE_API_TERMINAL_H
 
-#include <ZycoreExportConfig.h>
 #include <Zycore/LibC.h>
 #include <Zycore/Status.h>
 

--- a/include/Zycore/API/Thread.h
+++ b/include/Zycore/API/Thread.h
@@ -32,7 +32,6 @@
 #ifndef ZYCORE_API_THREAD_H
 #define ZYCORE_API_THREAD_H
 
-#include <ZycoreExportConfig.h>
 #include <Zycore/Defines.h>
 #include <Zycore/Status.h>
 

--- a/include/Zycore/Allocator.h
+++ b/include/Zycore/Allocator.h
@@ -32,7 +32,6 @@
 #ifndef ZYCORE_ALLOCATOR_H
 #define ZYCORE_ALLOCATOR_H
 
-#include <ZycoreExportConfig.h>
 #include <Zycore/Status.h>
 #include <Zycore/Types.h>
 

--- a/include/Zycore/Bitset.h
+++ b/include/Zycore/Bitset.h
@@ -32,7 +32,6 @@
 #ifndef ZYCORE_BITSET_H
 #define ZYCORE_BITSET_H
 
-#include <ZycoreExportConfig.h>
 #include <Zycore/Allocator.h>
 #include <Zycore/Status.h>
 #include <Zycore/Types.h>

--- a/include/Zycore/Defines.h
+++ b/include/Zycore/Defines.h
@@ -161,6 +161,73 @@
 #endif
 
 /* ============================================================================================== */
+/* Deprecation hint                                                                               */
+/* ============================================================================================== */
+
+#if defined(ZYAN_GCC) || defined(ZYAN_CLANG)
+#   define ZYAN_DEPRECATED __attribute__((__deprecated__))
+#elif defined(ZYAN_MSVC)
+#   define ZYAN_DEPRECATED __declspec(deprecated)
+#else
+#   define ZYAN_DEPRECATED
+#endif
+
+/* ============================================================================================== */
+/* Generic DLL import/export helpers                                                              */
+/* ============================================================================================== */
+
+#if defined(ZYAN_MSVC)
+#   define ZYAN_DLLEXPORT __declspec(dllexport)
+#   define ZYAN_DLLIMPORT __declspec(dllimport)
+#else
+#   define ZYAN_DLLEXPORT
+#   define ZYAN_DLLIMPORT
+#endif
+
+/* ============================================================================================== */
+/* Zycore dll{export,import}                                                                      */
+/* ============================================================================================== */
+
+// This is a cut-down version of what CMake's `GenerateExportHeader` would usually generate. To
+// simplify builds without CMake, we define these things manually instead of relying on CMake
+// to generate the header.
+//
+// For static builds, our CMakeList will define `ZYCORE_STATIC_BUILD`. For shared library builds,
+// our CMake will define `ZYCORE_SHOULD_EXPORT` depending on whether the target is being imported or
+// exported. If CMake isn't used, users can manually define these to fit their use-case.
+
+// Backward compatibility: CMake would previously generate these variables names. However, because
+// they have pretty cryptic names, we renamed them when we got rid of `GenerateExportHeader`. For
+// backward compatibility for users that don't use CMake and previously manually defined these, we
+// translate the old defines here and print a warning.
+#if defined(ZYCORE_STATIC_DEFINE)
+#   pragma message("ZYCORE_STATIC_DEFINE was renamed to ZYCORE_STATIC_BUILD.")
+#   define ZYCORE_STATIC_BUILD
+#endif
+#if defined(Zycore_EXPORTS)
+#   pragma message("Zycore_EXPORTS was renamed to ZYCORE_SHOULD_EXPORT.")
+#   define ZYCORE_SHOULD_EXPORT
+#endif
+
+/**
+ * Symbol is exported in shared library builds.
+ */
+#if defined(ZYCORE_STATIC_BUILD)
+#   define ZYCORE_EXPORT
+#else
+#   if defined(ZYCORE_SHOULD_EXPORT)
+#       define ZYCORE_EXPORT ZYAN_DLLEXPORT
+#   else
+#       define ZYCORE_EXPORT ZYAN_DLLIMPORT
+#   endif
+#endif
+
+/**
+ * Symbol is not exported and for internal use only.
+ */
+#define ZYCORE_NO_EXPORT
+
+/* ============================================================================================== */
 /* Misc compatibility macros                                                                      */
 /* ============================================================================================== */
 

--- a/include/Zycore/Format.h
+++ b/include/Zycore/Format.h
@@ -32,7 +32,6 @@
 #ifndef ZYCORE_FORMAT_H
 #define ZYCORE_FORMAT_H
 
-#include <ZycoreExportConfig.h>
 #include <Zycore/Status.h>
 #include <Zycore/String.h>
 #include <Zycore/Types.h>

--- a/include/Zycore/List.h
+++ b/include/Zycore/List.h
@@ -32,7 +32,6 @@
 #ifndef ZYCORE_LIST_H
 #define ZYCORE_LIST_H
 
-#include <ZycoreExportConfig.h>
 #include <Zycore/Allocator.h>
 #include <Zycore/Object.h>
 #include <Zycore/Status.h>

--- a/include/Zycore/String.h
+++ b/include/Zycore/String.h
@@ -32,7 +32,6 @@
 #ifndef ZYCORE_STRING_H
 #define ZYCORE_STRING_H
 
-#include <ZycoreExportConfig.h>
 #include <Zycore/Allocator.h>
 #include <Zycore/Status.h>
 #include <Zycore/Types.h>

--- a/include/Zycore/Vector.h
+++ b/include/Zycore/Vector.h
@@ -32,7 +32,6 @@
 #ifndef ZYCORE_VECTOR_H
 #define ZYCORE_VECTOR_H
 
-#include <ZycoreExportConfig.h>
 #include <Zycore/Allocator.h>
 #include <Zycore/Comparison.h>
 #include <Zycore/Object.h>

--- a/include/Zycore/Zycore.h
+++ b/include/Zycore/Zycore.h
@@ -32,7 +32,6 @@
 #ifndef ZYCORE_H
 #define ZYCORE_H
 
-#include <ZycoreExportConfig.h>
 #include <Zycore/Types.h>
 
 // TODO:


### PR DESCRIPTION
This PR gets rid of the CMake generated `ZycoreExportConfig.h` header. It's annoying to deal with in non-CMake environments because CMake generates it for one specific compiler (so you can't just generate it once and use it everywhere) and also doesn't really provide much that we couldn't just as well detect at compile time.

Because the previous exports created by CMake were rather cryptic, I also took the opportunity to rename them:

- `ZYCORE_STATIC_DEFINE` -> `ZYCORE_STATIC_BUILD`
- `Zycore_EXPORTS` -> `ZYCORE_SHOULD_EXPORT`

There was a third define that we manually defined previously, `ZYCORE_EXPORTS` (mind the casing), which was seemingly unused, so I removed it.

Because we don't have CI here, I created a branch in the Zydis repo and updated the submodule. Builds just fine, results are [here](https://github.com/zyantific/zydis/runs/4703804777?check_suite_focus=true).

Once approved, I'll apply the same changes to Zydis.

