### PR TITLE
Switch minimum supported C standard to C11

### DIFF
--- a/cmake/zyan-functions.cmake
+++ b/cmake/zyan-functions.cmake
@@ -3,9 +3,7 @@
 # =============================================================================================== #
 
 function (zyan_set_common_flags target)
-    if (NOT MSVC)
-        target_compile_options("${target}" PRIVATE "-std=c99")
-    endif ()
+    set_target_properties("${target}" PROPERTIES C_STANDARD 11)
 
     if (ZYAN_DEV_MODE)
         # If in developer mode, be pedantic.


### PR DESCRIPTION
Upcoming changes in Zydis (use of anonymous unions) require C11. With the standard now being 11 years old, we decided (in direct communication) that it is probably acceptable to bump our requirements here.