### PR TITLE
Don't enable C11 for MSVC

### DIFF
--- a/cmake/zyan-functions.cmake
+++ b/cmake/zyan-functions.cmake
@@ -3,7 +3,14 @@
 # =============================================================================================== #
 
 function (zyan_set_common_flags target)
-    set_target_properties("${target}" PROPERTIES C_STANDARD 11)
+    if (MSVC)
+        # MSVC support for C11 is still pretty lacking, so we instead just disable the warnings
+        # about using non-standard C extensions.
+        target_compile_options("${target}" PUBLIC "/wd4201")
+    else ()
+        # For the more civilized compilers, we go with C11.
+        set_target_properties("${target}" PROPERTIES C_STANDARD 11)
+    endif ()
 
     if (ZYAN_DEV_MODE)
         # If in developer mode, be pedantic.


### PR DESCRIPTION
Turns out that the Windows world is not quite ready for C11 yet.