### PR TITLE
fix(Defines): also check for _M_RISCV64

### DIFF
--- a/include/Zycore/Defines.h
+++ b/include/Zycore/Defines.h
@@ -140,7 +140,7 @@
 #   define ZYAN_PPC64
 #elif defined(__powerpc__)
 #   define ZYAN_PPC
-#elif defined(__riscv) && __riscv_xlen == 64
+#elif defined(_M_RISCV64) || defined(__riscv) && __riscv_xlen == 64
 #   define ZYAN_RISCV64
 #else
 #   error "Unsupported architecture detected"


### PR DESCRIPTION
The patch submitted by Bo in https://bugs.debian.org/1015787 and #48 also checked for this additional define, but it was not part of 3e95307df7d7fe03a1d360953f45cc8803cb71ad. This patch adds the additional check.

@yuzibo this define [doesn't seem very widespread](https://github.com/search?q=_M_RISCV64&type=code), is it needed on any platform?