### PR TITLE
CMake: rename target `doc` -> `ZycoreDoc`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,9 +218,10 @@ install(DIRECTORY "include/" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 # =============================================================================================== #
 # Doxygen documentation                                                                           #
 # =============================================================================================== #
+
 find_package(Doxygen)
 if (DOXYGEN_FOUND)
-    doxygen_add_docs(doc "include/Zycore/" ALL)
+    doxygen_add_docs(ZycoreDoc "include/Zycore/" ALL)
     install(
         DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/html/"
         DESTINATION "${CMAKE_INSTALL_DOCDIR}/api"


### PR DESCRIPTION
Both the documentation target in zycore and zydis were previously called "doc" which caused a CMake error in zydis complaining about the same name being used twice.

```
CMake Error at /usr/share/cmake/Modules/FindDoxygen.cmake:1165 (add_custom_target):
  add_custom_target cannot create target "doc" because another target with
  the same name already exists.  The existing target is a custom target
  created in source directory "/home/ath/devel/zydis/dependencies/zycore".
  See documentation for policy CMP0002 for more details.
Call Stack (most recent call first):
  CMakeLists.txt:460 (doxygen_add_docs)
```

CC @Tachi107 