### PR TITLE
Fix no-libc build on "other" platforms

### DIFF
--- a/src/API/Process.c
+++ b/src/API/Process.c
@@ -25,6 +25,10 @@
 ***************************************************************************************************/
 
 #include <Zycore/Defines.h>
+#include <Zycore/API/Process.h>
+
+#ifndef ZYAN_NO_LIBC
+
 #if defined(ZYAN_WINDOWS)
 #if   defined(ZYAN_KERNEL)
 #      include <wdm.h>
@@ -36,9 +40,6 @@
 #else
 #   error "Unsupported platform detected"
 #endif
-#include <Zycore/API/Process.h>
-
-#ifndef ZYAN_NO_LIBC
 
 /* ============================================================================================== */
 /* Exported functions                                                                             */


### PR DESCRIPTION
The `ifdef` in `Process.c` previously didn't include the header selection, resulting in "Unsupported platform detected" on non-Windows/non-Unix platforms like Emscripten.