### PR TITLE
Better support for linux kernel

### DIFF
--- a/include/Zycore/Defines.h
+++ b/include/Zycore/Defines.h
@@ -474,6 +474,20 @@
  */
 #define ZYAN_ALIGN_DOWN(x, align) (((x) - 1) & ~((align) - 1))
 
+/**
+ * Divide the 64bit integer value by the given divisor.
+ *
+ * @param   n       Variable containing the dividend that will be updated with the result of the
+ *                  division.
+ * @param   divisor The divisor.
+ */
+#if defined(ZYAN_LINUX) && defined(ZYAN_KERNEL)
+#   include <asm/div64.h> /* do_div */
+#   define ZYAN_DIV64(n, divisor) do_div(n, divisor)
+#else
+#   define ZYAN_DIV64(n, divisor) (n /= divisor)
+#endif
+
 /* ---------------------------------------------------------------------------------------------- */
 /* Bit operations                                                                                 */
 /* ---------------------------------------------------------------------------------------------- */

--- a/include/Zycore/Types.h
+++ b/include/Zycore/Types.h
@@ -42,68 +42,172 @@
     (defined(ZYAN_MSVC) && defined(ZYAN_KERNEL)) // The WDK LibC lacks stdint.h.
     // No LibC mode, use compiler built-in types / macros.
 #   if defined(ZYAN_MSVC) || defined(ZYAN_ICC)
-        typedef unsigned __int8  ZyanU8;
-        typedef unsigned __int16 ZyanU16;
-        typedef unsigned __int32 ZyanU32;
-        typedef unsigned __int64 ZyanU64;
-        typedef   signed __int8  ZyanI8;
-        typedef   signed __int16 ZyanI16;
-        typedef   signed __int32 ZyanI32;
-        typedef   signed __int64 ZyanI64;
+        typedef unsigned __int8                 ZyanU8;
+        typedef unsigned __int16                ZyanU16;
+        typedef unsigned __int32                ZyanU32;
+        typedef unsigned __int64                ZyanU64;
+        typedef   signed __int8                 ZyanI8;
+        typedef   signed __int16                ZyanI16;
+        typedef   signed __int32                ZyanI32;
+        typedef   signed __int64                ZyanI64;
 #       if _WIN64
-           typedef ZyanU64       ZyanUSize;
-           typedef ZyanI64       ZyanISize;
-           typedef ZyanU64       ZyanUPointer;
-           typedef ZyanI64       ZyanIPointer;
+           typedef ZyanU64                      ZyanUSize;
+           typedef ZyanI64                      ZyanISize;
+           typedef ZyanU64                      ZyanUPointer;
+           typedef ZyanI64                      ZyanIPointer;
 #       else
-           typedef ZyanU32       ZyanUSize;
-           typedef ZyanI32       ZyanISize;
-           typedef ZyanU32       ZyanUPointer;
-           typedef ZyanI32       ZyanIPointer;
+           typedef ZyanU32                      ZyanUSize;
+           typedef ZyanI32                      ZyanISize;
+           typedef ZyanU32                      ZyanUPointer;
+           typedef ZyanI32                      ZyanIPointer;
 #       endif
 #   elif defined(ZYAN_GNUC)
-        typedef __UINT8_TYPE__   ZyanU8;
-        typedef __UINT16_TYPE__  ZyanU16;
-        typedef __UINT32_TYPE__  ZyanU32;
-        typedef __UINT64_TYPE__  ZyanU64;
-        typedef __INT8_TYPE__    ZyanI8;
-        typedef __INT16_TYPE__   ZyanI16;
-        typedef __INT32_TYPE__   ZyanI32;
-        typedef __INT64_TYPE__   ZyanI64;
-        typedef __SIZE_TYPE__    ZyanUSize;
-        typedef __PTRDIFF_TYPE__ ZyanISize;
-        typedef __UINTPTR_TYPE__ ZyanUPointer;
-        typedef __INTPTR_TYPE__  ZyanIPointer;
+#       ifdef __UINT8_TYPE__
+            typedef __UINT8_TYPE__              ZyanU8;
+#       else
+            typedef unsigned char               ZyanU8;
+#       endif
+#       ifdef __UINT16_TYPE__
+            typedef __UINT16_TYPE__             ZyanU16;
+#       else
+            typedef unsigned short int          ZyanU16;
+#       endif
+#       ifdef __UINT32_TYPE__
+            typedef __UINT32_TYPE__             ZyanU32;
+#       else
+            typedef unsigned int                ZyanU32;
+#       endif
+#       ifdef __UINT64_TYPE__
+            typedef __UINT64_TYPE__             ZyanU64;
+#       else
+#           if defined(__x86_64__) && !defined(__ILP32__)
+                typedef unsigned long int       ZyanU64;
+#           else
+                typedef unsigned long long int  ZyanU64;
+#           endif
+#       endif
+#       ifdef __INT8_TYPE__
+            typedef __INT8_TYPE__               ZyanI8;
+#       else
+            typedef signed char                 ZyanI8;
+#       endif
+#       ifdef __INT16_TYPE__
+            typedef __INT16_TYPE__              ZyanI16;
+#       else
+            typedef signed short int            ZyanI16;
+#       endif
+#       ifdef __INT32_TYPE__
+            typedef __INT32_TYPE__              ZyanI32;
+#       else
+            typedef signed int                  ZyanI32;
+#       endif
+#       ifdef __INT64_TYPE__
+            typedef __INT64_TYPE__              ZyanI64;
+#       else
+#           if defined(__x86_64__) && !defined( __ILP32__)
+                typedef signed long int         ZyanI64;
+#           else
+                typedef signed long long int    ZyanI64;
+#           endif
+#       endif
+#       ifdef __SIZE_TYPE__
+            typedef __SIZE_TYPE__               ZyanUSize;
+#       else
+            typedef long unsigned int           ZyanUSize;
+#       endif
+#       ifdef __PTRDIFF_TYPE__
+            typedef __PTRDIFF_TYPE__            ZyanISize;
+#       else
+            typedef long int                    ZyanISize;
+#       endif
+#       ifdef __UINTPTR_TYPE__
+            typedef __UINTPTR_TYPE__            ZyanUPointer;
+#       else
+#           if defined(__x86_64__) && !defined( __ILP32__)
+                typedef unsigned long int       ZyanUPointer;
+#           else
+                typedef unsigned int            ZyanUPointer;
+#           endif
+#       endif
+#       ifdef __INTPTR_TYPE__
+            typedef __INTPTR_TYPE__             ZyanIPointer;
+#       else
+#           if defined(__x86_64__) && !defined( __ILP32__)
+                typedef long int                ZyanIPointer;
+#           else
+                typedef int                     ZyanIPointer;
+#           endif
+#       endif
 #   else
 #       error "Unsupported compiler for no-libc mode."
 #   endif
 
 #   if defined(ZYAN_MSVC)
-#       define ZYAN_INT8_MIN     (-127i8 - 1)
-#       define ZYAN_INT16_MIN    (-32767i16 - 1)
-#       define ZYAN_INT32_MIN    (-2147483647i32 - 1)
-#       define ZYAN_INT64_MIN    (-9223372036854775807i64 - 1)
-#       define ZYAN_INT8_MAX     127i8
-#       define ZYAN_INT16_MAX    32767i16
-#       define ZYAN_INT32_MAX    2147483647i32
-#       define ZYAN_INT64_MAX    9223372036854775807i64
-#       define ZYAN_UINT8_MAX    0xffui8
-#       define ZYAN_UINT16_MAX   0xffffui16
-#       define ZYAN_UINT32_MAX   0xffffffffui32
-#       define ZYAN_UINT64_MAX   0xffffffffffffffffui64
+#       define ZYAN_INT8_MIN            (-127i8 - 1)
+#       define ZYAN_INT16_MIN           (-32767i16 - 1)
+#       define ZYAN_INT32_MIN           (-2147483647i32 - 1)
+#       define ZYAN_INT64_MIN           (-9223372036854775807i64 - 1)
+#       define ZYAN_INT8_MAX            127i8
+#       define ZYAN_INT16_MAX           32767i16
+#       define ZYAN_INT32_MAX           2147483647i32
+#       define ZYAN_INT64_MAX           9223372036854775807i64
+#       define ZYAN_UINT8_MAX           0xffui8
+#       define ZYAN_UINT16_MAX          0xffffui16
+#       define ZYAN_UINT32_MAX          0xffffffffui32
+#       define ZYAN_UINT64_MAX          0xffffffffffffffffui64
 #   else
-#       define ZYAN_INT8_MAX     __INT8_MAX__
-#       define ZYAN_INT8_MIN     (-ZYAN_INT8_MAX - 1)
-#       define ZYAN_INT16_MAX    __INT16_MAX__
-#       define ZYAN_INT16_MIN    (-ZYAN_INT16_MAX - 1)
-#       define ZYAN_INT32_MAX    __INT32_MAX__
-#       define ZYAN_INT32_MIN    (-ZYAN_INT32_MAX - 1)
-#       define ZYAN_INT64_MAX    __INT64_MAX__
-#       define ZYAN_INT64_MIN    (-ZYAN_INT64_MAX - 1)
-#       define ZYAN_UINT8_MAX    __UINT8_MAX__
-#       define ZYAN_UINT16_MAX   __UINT16_MAX__
-#       define ZYAN_UINT32_MAX   __UINT32_MAX__
-#       define ZYAN_UINT64_MAX   __UINT64_MAX__
+#       ifdef __INT8_MAX__
+#           define ZYAN_INT8_MAX        __INT8_MAX__
+#       else
+#           define ZYAN_INT8_MAX        (127)
+#       endif
+#       define ZYAN_INT8_MIN            (-ZYAN_INT8_MAX - 1)
+#       ifdef __INT16_MAX__
+#           define ZYAN_INT16_MAX       __INT16_MAX__
+#       else
+#           define ZYAN_INT16_MAX       (32767)
+#       endif
+#       define ZYAN_INT16_MIN           (-ZYAN_INT16_MAX - 1)
+#       ifdef __INT32_MAX__
+#           define ZYAN_INT32_MAX       __INT32_MAX__
+#       else
+#           define ZYAN_INT32_MAX       (2147483647)
+#       endif
+#       define ZYAN_INT32_MIN           (-ZYAN_INT32_MAX - 1)
+#       ifdef __INT64_MAX__
+#           define ZYAN_INT64_MAX       __INT64_MAX__
+#       else
+#           if defined(__x86_64__) && !defined( __ILP32__)
+#               define ZYAN_INT64_MAX   (9223372036854775807L)
+#           else
+#               define ZYAN_INT64_MAX   (9223372036854775807LL)
+#           endif
+#       endif
+#       define ZYAN_INT64_MIN           (-ZYAN_INT64_MAX - 1)
+#       ifdef __UINT8_MAX__
+#           define ZYAN_UINT8_MAX       __UINT8_MAX__
+#       else
+#           define ZYAN_UINT8_MAX       (255)
+#       endif
+#       ifdef __UINT16_MAX__
+#           define ZYAN_UINT16_MAX      __UINT16_MAX__
+#       else
+#           define ZYAN_UINT16_MAX      (65535)
+#       endif
+#       ifdef __UINT32_MAX__
+#           define ZYAN_UINT32_MAX      __UINT32_MAX__
+#       else
+#           define ZYAN_UINT32_MAX      (4294967295U)
+#       endif
+#       ifdef __UINT64_MAX__
+#           define ZYAN_UINT64_MAX      __UINT64_MAX__
+#       else
+#           if defined(__x86_64__) && !defined( __ILP32__)
+#               define ZYAN_UINT64_MAX  (18446744073709551615UL)
+#           else
+#               define ZYAN_UINT64_MAX  (18446744073709551615ULL)
+#           endif
+#       endif
 #   endif
 #else
     // If is LibC present, we use stdint types.


### PR DESCRIPTION
Hi,

These two commits improve support for building Zydis for the linux kernel in a couple of corner cases:

The first commit introduces the ZYAN_DIV64 macro to fix a failure when linking Zydis on a 32bit linux kernel. The Zydis changes will be submitted in a separate PR.

The second PR adds support for building Zydis in NO_LIBC mode with old versions of GCC.

Thanks,
