### PR TITLE
Add `ZYAN_GETENV` macro to `LibC.h`

### DIFF
--- a/include/Zycore/LibC.h
+++ b/include/Zycore/LibC.h
@@ -99,6 +99,7 @@ typedef FILE ZyanFile;
 #include <stdlib.h>
 #define ZYAN_CALLOC     calloc
 #define ZYAN_FREE       free
+#define ZYAN_GETENV     getenv
 #define ZYAN_MALLOC     malloc
 #define ZYAN_REALLOC    realloc
 


### PR DESCRIPTION
This is needed in `ZydisInfo` and `ZydisDisasm` to support the [NO_COLOR](https://no-color.org/) informal standard.