### PR TITLE
Add missing `(void)` on functions without args

### DIFF
--- a/include/Zycore/API/Memory.h
+++ b/include/Zycore/API/Memory.h
@@ -87,7 +87,7 @@ typedef enum ZyanMemoryPageProtection_
  *
  * @return  The system page size.
  */
-ZYCORE_EXPORT ZyanU32 ZyanMemoryGetSystemPageSize();
+ZYCORE_EXPORT ZyanU32 ZyanMemoryGetSystemPageSize(void);
 
 /**
  * Returns the system allocation granularity.
@@ -100,7 +100,7 @@ ZYCORE_EXPORT ZyanU32 ZyanMemoryGetSystemPageSize();
  *
  * @return  The system allocation granularity.
  */
-ZYCORE_EXPORT ZyanU32 ZyanMemoryGetSystemAllocationGranularity();
+ZYCORE_EXPORT ZyanU32 ZyanMemoryGetSystemAllocationGranularity(void);
 
 /* ---------------------------------------------------------------------------------------------- */
 /* Memory management                                                                              */

--- a/src/API/Memory.c
+++ b/src/API/Memory.c
@@ -44,7 +44,7 @@
 /* General                                                                                        */
 /* ---------------------------------------------------------------------------------------------- */
 
-ZyanU32 ZyanMemoryGetSystemPageSize()
+ZyanU32 ZyanMemoryGetSystemPageSize(void)
 {
 #if defined(ZYAN_WINDOWS)
 
@@ -60,7 +60,7 @@ ZyanU32 ZyanMemoryGetSystemPageSize()
 #endif
 }
 
-ZyanU32 ZyanMemoryGetSystemAllocationGranularity()
+ZyanU32 ZyanMemoryGetSystemAllocationGranularity(void)
 {
 #if defined(ZYAN_WINDOWS)
 


### PR DESCRIPTION
Multiple functions without arguments were missing the `(void)` that prevents them from being interpreted as not having a prototype. Newer Clang versions started printing warnings for that in pedantic mode.

Will send similar PR for Zydis once this is merged.