### PR TITLE
Bump version to v1.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.15")
     cmake_policy(SET CMP0091 NEW)
 endif ()
 
-project(Zycore VERSION 1.4.0.0 LANGUAGES C)
+project(Zycore VERSION 1.5.0.0 LANGUAGES C)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)

--- a/include/Zycore/Zycore.h
+++ b/include/Zycore/Zycore.h
@@ -51,7 +51,7 @@ extern "C" {
 /**
  * A macro that defines the zycore version.
  */
-#define ZYCORE_VERSION (ZyanU64)0x0001000400010000
+#define ZYCORE_VERSION (ZyanU64)0x0001000500000000
 
 /* ---------------------------------------------------------------------------------------------- */
 /* Helper macros                                                                                  */

--- a/resources/VersionInfo.rc
+++ b/resources/VersionInfo.rc
@@ -27,8 +27,8 @@
 #include "winres.h"
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,4,1,0
- PRODUCTVERSION 1,4,1,0
+ FILEVERSION 1,5,0,0
+ PRODUCTVERSION 1,5,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -45,12 +45,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "zyantific"
             VALUE "FileDescription", "Zyan Core Library for C"
-            VALUE "FileVersion", "1.4.1.0"
+            VALUE "FileVersion", "1.5.0.0"
             VALUE "InternalName", "Zycore"
-            VALUE "LegalCopyright", "Copyright © 2018-2022 by zyantific.com"
+            VALUE "LegalCopyright", "Copyright © 2018-2024 by zyantific.com"
             VALUE "OriginalFilename", "Zycore.dll"
             VALUE "ProductName", "Zyan Core Library for C"
-            VALUE "ProductVersion", "1.4.1.0"
+            VALUE "ProductVersion", "1.5.0.0"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
Cut a new release of Zycore to be used in Zydis v4.1 release.

Commits included: https://github.com/zyantific/zycore-c/compare/v1.4.1...master

Going with v1.5.0 (instead of v1.4.1) because the `ZYAN_GETENV` macro that we added is needed by Zycore, so distro maintainers will have to update Zycore first.