### PR TITLE
Fix issue with `llvm-rc` when `ZYCORE_BUILD_SHARED_LIB` is enabled

### DIFF
--- a/resources/VersionInfo.rc
+++ b/resources/VersionInfo.rc
@@ -47,7 +47,7 @@ BEGIN
             VALUE "FileDescription", "Zyan Core Library for C"
             VALUE "FileVersion", "1.5.0.0"
             VALUE "InternalName", "Zycore"
-            VALUE "LegalCopyright", "Copyright © 2018-2024 by zyantific.com"
+            VALUE "LegalCopyright", "Copyright (C) 2018-2024 by zyantific.com"
             VALUE "OriginalFilename", "Zycore.dll"
             VALUE "ProductName", "Zyan Core Library for C"
             VALUE "ProductVersion", "1.5.0.0"


### PR DESCRIPTION
If `llvm-rc` is used as the resource compiler, the following error occurs if `ZYCORE_BUILD_SHARED_LIB` is enabled:
```
llvm-rc: Error in VERSIONINFO statement (ID 1):
Non-ASCII 8-bit codepoint (∩┐╜) can't be interpreted in the current codepage
```
This is a common issue encountered with `llvm-rc`, see curl/curl#7765.
Following the workaround from  `libcurl`, this pull request changes the copyright symbol `©` to `(C)`.