### PR TITLE
Add alias target "Zycore::Zycore"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ else ()
     add_library("Zycore" STATIC)
     target_compile_definitions("Zycore" PUBLIC "ZYCORE_STATIC_BUILD")
 endif ()
+add_library("Zycore::Zycore" ALIAS "Zycore")
 
 set_target_properties("Zycore" PROPERTIES
     LINKER_LANGUAGE C


### PR DESCRIPTION
To offer the same public target regardless of zycore-c is used as a subproject or via `find_package`.
This should be complemented by Zydis linking "Zycore::Zycore".

(Noticed in reviewing a vcpkg port update.)