### PR TITLE
Bump version to `v1.5.2`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.15")
     cmake_policy(SET CMP0091 NEW)
 endif ()
 
-project(Zycore VERSION 1.5.1.0 LANGUAGES C)
+project(Zycore VERSION 1.5.2.0 LANGUAGES C)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)

--- a/include/Zycore/Zycore.h
+++ b/include/Zycore/Zycore.h
@@ -51,7 +51,7 @@ extern "C" {
 /**
  * A macro that defines the zycore version.
  */
-#define ZYCORE_VERSION 0x0001000500010000ULL
+#define ZYCORE_VERSION 0x0001000500020000ULL
 
 /* ---------------------------------------------------------------------------------------------- */
 /* Helper macros                                                                                  */

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'Zycore',
   'c',
-  version: '1.5.1',
+  version: '1.5.2',
   license: 'MIT',
   license_files: 'LICENSE',
   meson_version: '>=1.3',

--- a/resources/VersionInfo.rc
+++ b/resources/VersionInfo.rc
@@ -27,8 +27,8 @@
 #include "winres.h"
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,5,1,0
- PRODUCTVERSION 1,5,1,0
+ FILEVERSION 1,5,2,0
+ PRODUCTVERSION 1,5,2,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -45,12 +45,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "zyantific"
             VALUE "FileDescription", "Zyan Core Library for C"
-            VALUE "FileVersion", "1.5.1.0"
+            VALUE "FileVersion", "1.5.2.0"
             VALUE "InternalName", "Zycore"
-            VALUE "LegalCopyright", "Copyright \xA9 2018-2024 by zyantific.com"
+            VALUE "LegalCopyright", "Copyright \xA9 2018-2025 by zyantific.com"
             VALUE "OriginalFilename", "Zycore.dll"
             VALUE "ProductName", "Zyan Core Library for C"
-            VALUE "ProductVersion", "1.5.1.0"
+            VALUE "ProductVersion", "1.5.2.0"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
Create another Zycore release including a bunch of the recent fix-ups in prep for [the Zydis 4.1.1 release](https://github.com/zyantific/zydis/pull/547).

CC @mochaaP