### PR TITLE
chore: bump min cmake version to 3.10, update googletest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ if (TARGET Zycore)
     return()
 endif ()
 
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.15")
     # Enable runtime library selection via CMAKE_MSVC_RUNTIME_LIBRARY

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,11 +1,11 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 project(googletest-download NONE)
 
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           ee3aa831172090fd5442820f215cb04ab6062756
+  GIT_TAG           v1.17.0
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/gtest/src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/gtest/build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
This PR fixes build errors on newer versions of CMake. Since [version 3.10 was released in 2018](https://github.com/Kitware/CMake/releases/tag/v3.10.0), it makes sense to update to the min version.
<details>
<summary>build errors (click to expand)</summary>

```
$ cmake --version
cmake version 4.0.1

$ mkdir -p build && cd build
$ cmake ..
CMake Deprecation Warning at CMakeLists.txt:5 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

-- The C compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE) 
-- Configuring done (0.3s)
-- Generating done (0.0s)
-- Build files have been written to: /tmp/zycore-c/build
```

```
$ mkdir -p build && cd build
$ cmake -DZYCORE_BUILD_TESTS=ON ..
CMake Deprecation Warning at CMakeLists.txt:5 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.


-- The C compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


-- Configuring incomplete, errors occurred!
CMake Error at CMakeLists.txt:88 (message):
  CMake step for googletest failed: 1


-- Configuring incomplete, errors occurred!
```
</details>
