### PR TITLE
Added `ZYAN_ARCHITECTURE_WIDTH`

### DIFF
--- a/include/Zycore/Defines.h
+++ b/include/Zycore/Defines.h
@@ -164,25 +164,35 @@
 
 #if defined(_M_AMD64) || defined(__x86_64__)
 #   define ZYAN_X64
+#   define ZYAN_ARCHITECTURE_WIDTH 64
 #elif defined(_M_IX86) || defined(__i386__)
 #   define ZYAN_X86
+#   define ZYAN_ARCHITECTURE_WIDTH 32
 #elif defined(_M_ARM64) || defined(__aarch64__)
 #   define ZYAN_AARCH64
+#   define ZYAN_ARCHITECTURE_WIDTH 64
 #elif defined(_M_ARM) || defined(_M_ARMT) || defined(__arm__) || defined(__thumb__)
 #   define ZYAN_ARM
+#   define ZYAN_ARCHITECTURE_WIDTH 32
 #elif defined(__EMSCRIPTEN__) || defined(__wasm__) || defined(__WASM__)
 #   define ZYAN_WASM
+#   define ZYAN_ARCHITECTURE_WIDTH 32
 #elif defined(__loongarch__)
 #   define ZYAN_LOONGARCH
+#   define ZYAN_ARCHITECTURE_WIDTH 64
 #elif defined(__powerpc64__)
 #   define ZYAN_PPC64
+#   define ZYAN_ARCHITECTURE_WIDTH 64
 #elif defined(__powerpc__)
 #   define ZYAN_PPC
+#   define ZYAN_ARCHITECTURE_WIDTH 32
 #elif defined(__riscv) || defined(__riscv__)
 #   if __riscv_xlen == 64
 #       define ZYAN_RISCV64
+#       define ZYAN_ARCHITECTURE_WIDTH 64
 #   else
 #       define ZYAN_RISCV32
+#       define ZYAN_ARCHITECTURE_WIDTH 32
 #   endif
 #elif defined(__arc__)
 #   define ZYAN_ARC
@@ -194,6 +204,14 @@
 #   define ZYAN_MIPS
 #else
 #   error "Unsupported architecture detected"
+#endif
+
+#if !defined(ZYAN_ARCHITECTURE_WIDTH)
+#   if defined(__LP64__)
+#       define ZYAN_ARCHITECTURE_WIDTH 64
+#   else
+#       define ZYAN_ARCHITECTURE_WIDTH 32
+#   endif
 #endif
 
 /* ============================================================================================== */

--- a/src/Format.c
+++ b/src/Format.c
@@ -83,7 +83,7 @@ static const ZyanStringView STR_SUB = ZYAN_DEFINE_STRING_VIEW("-");
 /* Decimal                                                                                        */
 /* ---------------------------------------------------------------------------------------------- */
 
-#if defined(ZYAN_X86) || defined(ZYAN_ARM) || defined(ZYAN_EMSCRIPTEN) || defined(ZYAN_WASM) || defined(ZYAN_PPC)
+#if ZYAN_ARCHITECTURE_WIDTH != 64
 ZyanStatus ZyanStringAppendDecU32(ZyanString* string, ZyanU32 value, ZyanU8 padding_length)
 {
     if (!string)
@@ -179,7 +179,7 @@ ZyanStatus ZyanStringAppendDecU64(ZyanString* string, ZyanU64 value, ZyanU8 padd
 /* Hexadecimal                                                                                    */
 /* ---------------------------------------------------------------------------------------------- */
 
-#if defined(ZYAN_X86) || defined(ZYAN_ARM) || defined(ZYAN_EMSCRIPTEN) || defined(ZYAN_WASM) || defined(ZYAN_PPC)
+#if ZYAN_ARCHITECTURE_WIDTH != 64
 ZyanStatus ZyanStringAppendHexU32(ZyanString* string, ZyanU32 value, ZyanU8 padding_length,
     ZyanBool uppercase)
 {
@@ -423,7 +423,7 @@ ZyanStatus ZyanStringAppendFormat(ZyanString* string, const char* format, ...)
 
 ZyanStatus ZyanStringAppendDecU(ZyanString* string, ZyanU64 value, ZyanU8 padding_length)
 {
-#if defined(ZYAN_X64) || defined(ZYAN_AARCH64) || defined(ZYAN_PPC64) || defined(ZYAN_RISCV64) || defined(ZYAN_LOONGARCH)
+#if ZYAN_ARCHITECTURE_WIDTH == 64
     return ZyanStringAppendDecU64(string, value, padding_length);
 #else
     // Working with 64-bit values is slow on non 64-bit systems
@@ -464,7 +464,7 @@ ZyanStatus ZyanStringAppendDecS(ZyanString* string, ZyanI64 value, ZyanU8 paddin
 ZyanStatus ZyanStringAppendHexU(ZyanString* string, ZyanU64 value, ZyanU8 padding_length,
     ZyanBool uppercase)
 {
-#if defined(ZYAN_X64) || defined(ZYAN_AARCH64) || defined(ZYAN_PPC64) || defined(ZYAN_RISCV64) || defined(ZYAN_LOONGARCH)
+#if ZYAN_ARCHITECTURE_WIDTH == 64
     return ZyanStringAppendHexU64(string, value, padding_length, uppercase);
 #else
     // Working with 64-bit values is slow on non 64-bit systems


### PR DESCRIPTION
PR to address problem brought up in https://github.com/zyantific/zycore-c/pull/87#issuecomment-2889189580 and https://github.com/zyantific/zydis/pull/572.

`ZYAN_ARCHITECTURE_WIDTH` is hardcoded for well-known architectures. For others `__LP64__` check is performed on a best effort basis. Generally it should be reliable and it seems to be widely used.

Conditions in `src/Format.c` are now inverses of each other to avoid desync issues (like in https://github.com/zyantific/zydis/pull/572).