### PR TITLE
Status.h: Make ZYAN_FAILED return ZYAN_FALSE or ZYAN_TRUE

### DIFF
--- a/include/Zycore/Status.h
+++ b/include/Zycore/Status.h
@@ -89,7 +89,7 @@ typedef ZyanU32 ZyanStatus;
  * @return  `ZYAN_TRUE`, if the operation failed or `ZYAN_FALSE`, if not.
  */
 #define ZYAN_FAILED(status) \
-    ((status) & 0x80000000u)
+    (!!((status) & 0x80000000u))
 
 /**
  * Checks if a zyan operation was successful and returns with the status-code, if not.


### PR DESCRIPTION
ZYAN_TRUE is 1, not 0x80000000

(good job github, why do you highlight that start paren as deleted)