### PR TITLE
Scope MSVC PUBLIC target_compile_options to C,CXX

### DIFF
--- a/cmake/zyan-functions.cmake
+++ b/cmake/zyan-functions.cmake
@@ -6,7 +6,7 @@ function (zyan_set_common_flags target)
     if (MSVC)
         # MSVC support for C11 is still pretty lacking, so we instead just disable the warnings
         # about using non-standard C extensions.
-        target_compile_options("${target}" PUBLIC "/wd4201")
+        target_compile_options("${target}" PUBLIC $<$<COMPILE_LANGUAGE:C,CXX>:/wd4201>)
     else ()
         # For the more civilized compilers, we go with C11.
         set_target_properties("${target}" PROPERTIES C_STANDARD 11)
@@ -15,7 +15,7 @@ function (zyan_set_common_flags target)
     if (ZYAN_DEV_MODE)
         # If in developer mode, be pedantic.
         if (MSVC)
-            target_compile_options("${target}" PUBLIC "/WX" "/W4")
+            target_compile_options("${target}" PUBLIC $<$<COMPILE_LANGUAGE:C,CXX>:/WX> $<$<COMPILE_LANGUAGE:C,CXX>:/W4>)
         else ()
             target_compile_options("${target}" PUBLIC "-Wall" "-pedantic" "-Wextra" "-Werror")
         endif ()


### PR DESCRIPTION
Currently, `/wd4201` (and in dev mode, `/WX` + `/W4`) is unconditionally added to the `PUBLIC` compile options:
```cmake
function (zyan_set_common_flags target)
    if (MSVC)
        # MSVC support for C11 is still pretty lacking, so we instead just disable the warnings
        # about using non-standard C extensions.
        target_compile_options("${target}" PUBLIC "/wd4201")
```
 This causes warnings to be emitted if you consume Zycore (in my case, through Zydis) from a project using MASM as it does not recognize `/wd4201` yet still receives it on the command line:
 
<img width="348" height="124" alt="image" src="https://github.com/user-attachments/assets/08ad3f95-049c-4758-ab95-a12de653a5ce" />
 
This PR resolves the issue by scoping the options to the `C` and `CXX` languages (as suggested in the [`target_compile_options`](https://cmake.org/cmake/help/latest/command/target_compile_options.html#see-also) documentation) which prevents them from being passed to `ASM_MASM` compilers. I haven't applied the same changes to the non-MSVC options, but could if that's preferred.