### PR TITLE
fix: define ZYAN_PRINTF_ATTR on clang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,7 @@ doc/html
 /.vscode
 /.idea
 /cmake-build-*
+
+# subproject directories
+/subprojects/*
+!/subprojects/*.wrap

--- a/include/Zycore/Defines.h
+++ b/include/Zycore/Defines.h
@@ -476,7 +476,7 @@
 #if defined(__RESHARPER__)
 #   define ZYAN_PRINTF_ATTR(format_index, first_to_check) \
         [[gnu::format(printf, format_index, first_to_check)]]
-#elif defined(ZYAN_GCC)
+#elif defined(ZYAN_GNUC)
 #   define ZYAN_PRINTF_ATTR(format_index, first_to_check) \
         __attribute__((format(printf, format_index, first_to_check)))
 #else


### PR DESCRIPTION
- **fix: define ZYAN_PRINTF_ATTR on clang**
- **ignore meson downloaded subprojects**
