### PR TITLE
Add OpenBSD detection

### DIFF
--- a/include/Zycore/Defines.h
+++ b/include/Zycore/Defines.h
@@ -130,6 +130,9 @@
 #elif defined(__NetBSD__)
 #   define ZYAN_NETBSD
 #   define ZYAN_POSIX
+#elif defined(__OpenBSD__)
+#   define ZYAN_OPENBSD
+#   define ZYAN_POSIX
 #elif defined(sun) || defined(__sun)
 #   define ZYAN_SOLARIS
 #   define ZYAN_POSIX


### PR DESCRIPTION
Tested on OpenBSD/sparc64, this will be necessary to get ZydisPerfTest to work there.
Overall, zycore seems to work fine on that platform and the unit tests pass.