### PR TITLE
Add virtual-memory and thread-control primitives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,7 @@ target_sources("Zycore"
         "src/API/Synchronization.c"
         "src/API/Terminal.c"
         "src/API/Thread.c"
+        "src/API/ThreadControl.c"
         # Common
         "src/Allocator.c"
         "src/ArgParse.c"
@@ -278,7 +279,7 @@ endif ()
 
 function (zyan_add_test test)
     add_executable("Test${test}" "tests/${test}.cpp")
-    target_link_libraries("Test${test}" "Zycore" "gtest")
+    target_link_libraries("Test${test}" "Zycore" "gtest" Threads::Threads)
     set_target_properties("Test${test}" PROPERTIES
         LANGUAGE CXX
         CXX_STANDARD 17
@@ -294,10 +295,12 @@ endfunction ()
 if (ZYCORE_BUILD_TESTS)
     enable_language(CXX)
     enable_testing()
+    find_package(Threads REQUIRED)
     zyan_add_test("String")
     zyan_add_test("Vector")
     zyan_add_test("ArgParse")
     zyan_add_test("Memory")
+    zyan_add_test("ThreadControl")
 endif ()
 
 # =============================================================================================== #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,6 +297,7 @@ if (ZYCORE_BUILD_TESTS)
     zyan_add_test("String")
     zyan_add_test("Vector")
     zyan_add_test("ArgParse")
+    zyan_add_test("Memory")
 endif ()
 
 # =============================================================================================== #

--- a/include/Zycore/API/Memory.h
+++ b/include/Zycore/API/Memory.h
@@ -38,6 +38,10 @@
 
 #ifndef ZYAN_NO_LIBC
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if   defined(ZYAN_WINDOWS)
 #   include <windows.h>
 #elif defined(ZYAN_POSIX)
@@ -73,6 +77,29 @@ typedef enum ZyanMemoryPageProtection_
 
 #endif
 } ZyanMemoryPageProtection;
+
+/**
+ * Defines the `ZyanMemoryRegionState` enum.
+ */
+typedef enum ZyanMemoryRegionState_
+{
+    ZYAN_MEMORY_REGION_STATE_FREE,
+    ZYAN_MEMORY_REGION_STATE_RESERVED,
+    ZYAN_MEMORY_REGION_STATE_COMMITTED
+} ZyanMemoryRegionState;
+
+/**
+ * Defines the `ZyanMemoryRegionInfo` struct returned by `ZyanMemoryVirtualQuery`.
+ *
+ * `protection` is only meaningful when `state` is `ZYAN_MEMORY_REGION_STATE_COMMITTED`.
+ */
+typedef struct ZyanMemoryRegionInfo_
+{
+    void* base;
+    ZyanUSize size;
+    ZyanMemoryRegionState state;
+    ZyanMemoryPageProtection protection;
+} ZyanMemoryRegionInfo;
 
 /* ============================================================================================== */
 /* Exported functions                                                                             */
@@ -128,9 +155,47 @@ ZYCORE_EXPORT ZyanStatus ZyanMemoryVirtualProtect(void* address, ZyanUSize size,
  */
 ZYCORE_EXPORT ZyanStatus ZyanMemoryVirtualFree(void* address, ZyanUSize size);
 
+/**
+ * Reserves and commits `size` bytes of memory with the given `protection`.
+ *
+ * @param   address     On entry, the requested base (aligned to the system allocation
+ *                      granularity) or `ZYAN_NULL` to let the system choose. On success,
+ *                      receives the actual base.
+ * @param   size        The number of bytes to allocate.
+ * @param   protection  The initial page protection.
+ *
+ * A non-null requested base that cannot be satisfied exactly fails with
+ * `ZYAN_STATUS_BAD_SYSTEMCALL` rather than allocating elsewhere.
+ *
+ * @return  A zyan status code.
+ */
+ZYCORE_EXPORT ZyanStatus ZyanMemoryVirtualAlloc(void** address, ZyanUSize size,
+    ZyanMemoryPageProtection protection);
+
+/**
+ * Returns information about the virtual-memory region that contains `address`.
+ *
+ * @param   address The address to query.
+ * @param   info    Receives the region information.
+ *
+ * `base <= address < base + size` always holds. Free (unmapped) ranges are reported as
+ * `ZYAN_MEMORY_REGION_STATE_FREE`; on POSIX they are synthesized from the gaps between
+ * mappings. On macOS a free region may report `base == address` rather than the true
+ * lower bound of the gap; callers must rely only on `state`, `size`, and the invariant
+ * above.
+ *
+ * @return  A zyan status code.
+ */
+ZYCORE_EXPORT ZyanStatus ZyanMemoryVirtualQuery(const void* address,
+    ZyanMemoryRegionInfo* info);
+
 /* ---------------------------------------------------------------------------------------------- */
 
 /* ============================================================================================== */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZYAN_NO_LIBC */
 

--- a/include/Zycore/API/Memory.h
+++ b/include/Zycore/API/Memory.h
@@ -182,7 +182,8 @@ ZYCORE_EXPORT ZyanStatus ZyanMemoryVirtualAlloc(void** address, ZyanUSize size,
  * `ZYAN_MEMORY_REGION_STATE_FREE`; on POSIX they are synthesized from the gaps between
  * mappings. On macOS a free region may report `base == address` rather than the true
  * lower bound of the gap; callers must rely only on `state`, `size`, and the invariant
- * above.
+ * above. The sole exception is `address` at the very top of the address space (the last
+ * representable byte), which is never mappable in practice.
  *
  * @return  A zyan status code.
  */

--- a/include/Zycore/API/Thread.h
+++ b/include/Zycore/API/Thread.h
@@ -255,6 +255,9 @@ ZYCORE_EXPORT ZyanStatus ZyanThreadEnumerate(ZyanVector* thread_ids, ZyanBool in
  * Suspends the given thread. The thread must belong to the current process and must not be the
  * calling thread.
  *
+ * All calls to `ZyanThreadSuspend` and `ZyanThreadResume` must be issued from a single controlling
+ * thread; they are not safe to call concurrently for the same or different target threads.
+ *
  * @param   thread_id   A thread id obtained from `ZyanThreadEnumerate`.
  *
  * @return  A zyan status code.
@@ -263,6 +266,9 @@ ZYCORE_EXPORT ZyanStatus ZyanThreadSuspend(ZyanThreadId thread_id);
 
 /**
  * Resumes a thread previously suspended with `ZyanThreadSuspend`.
+ *
+ * All calls to `ZyanThreadSuspend` and `ZyanThreadResume` must be issued from a single controlling
+ * thread; they are not safe to call concurrently for the same or different target threads.
  *
  * @param   thread_id   A thread id obtained from `ZyanThreadEnumerate`.
  *

--- a/include/Zycore/API/Thread.h
+++ b/include/Zycore/API/Thread.h
@@ -34,6 +34,7 @@
 
 #include <Zycore/Defines.h>
 #include <Zycore/Status.h>
+#include <Zycore/Vector.h>
 
 #ifndef ZYAN_NO_LIBC
 
@@ -229,6 +230,66 @@ ZYCORE_EXPORT ZyanStatus ZyanThreadTlsGetValue(ZyanThreadTlsIndex index, void** 
  * @return  A zyan status code.
  */
 ZYCORE_EXPORT ZyanStatus ZyanThreadTlsSetValue(ZyanThreadTlsIndex index, void* data);
+
+/* ---------------------------------------------------------------------------------------------- */
+/* Thread control                                                                                 */
+/* ---------------------------------------------------------------------------------------------- */
+
+/**
+ * Enumerates the threads of the current process.
+ *
+ * @param   thread_ids      A `ZyanVector` (element size `sizeof(ZyanThreadId)`), initialised by
+ *                          the caller, that receives the thread ids.
+ * @param   include_current `ZYAN_TRUE` to include the calling thread, `ZYAN_FALSE` to exclude it.
+ *
+ * The ids produced here are the only values accepted by `ZyanThreadSuspend`, `ZyanThreadResume`,
+ * `ZyanThreadGetInstructionPointer`, and `ZyanThreadSetInstructionPointer`. Their concrete meaning
+ * is platform specific (kernel thread id on Linux, thread id on Windows, mach thread port on
+ * macOS) and must not be compared against values from `ZyanThreadGetCurrentThreadId`.
+ *
+ * @return  A zyan status code.
+ */
+ZYCORE_EXPORT ZyanStatus ZyanThreadEnumerate(ZyanVector* thread_ids, ZyanBool include_current);
+
+/**
+ * Suspends the given thread. The thread must belong to the current process and must not be the
+ * calling thread.
+ *
+ * @param   thread_id   A thread id obtained from `ZyanThreadEnumerate`.
+ *
+ * @return  A zyan status code.
+ */
+ZYCORE_EXPORT ZyanStatus ZyanThreadSuspend(ZyanThreadId thread_id);
+
+/**
+ * Resumes a thread previously suspended with `ZyanThreadSuspend`.
+ *
+ * @param   thread_id   A thread id obtained from `ZyanThreadEnumerate`.
+ *
+ * @return  A zyan status code.
+ */
+ZYCORE_EXPORT ZyanStatus ZyanThreadResume(ZyanThreadId thread_id);
+
+/**
+ * Reads the instruction pointer of a currently suspended thread.
+ *
+ * @param   thread_id   A thread id obtained from `ZyanThreadEnumerate`, currently suspended.
+ * @param   ip          Receives the instruction pointer.
+ *
+ * @return  A zyan status code.
+ */
+ZYCORE_EXPORT ZyanStatus ZyanThreadGetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer* ip);
+
+/**
+ * Sets the instruction pointer of a currently suspended thread. The new value takes effect when
+ * the thread is resumed.
+ *
+ * @param   thread_id   A thread id obtained from `ZyanThreadEnumerate`, currently suspended.
+ * @param   ip          The new instruction pointer.
+ *
+ * @return  A zyan status code.
+ */
+ZYCORE_EXPORT ZyanStatus ZyanThreadSetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer ip);
 
 /* ---------------------------------------------------------------------------------------------- */
 

--- a/include/Zycore/Defines.h
+++ b/include/Zycore/Defines.h
@@ -588,7 +588,7 @@
  *
  * Note that this macro only works for powers of 2.
  */
-#define ZYAN_ALIGN_DOWN(x, align) (((x) - 1) & ~((align) - 1))
+#define ZYAN_ALIGN_DOWN(x, align) ((x) & ~((align) - 1))
 
 /**
  * Divide the 64bit integer value by the given divisor.

--- a/src/API/Memory.c
+++ b/src/API/Memory.c
@@ -33,7 +33,7 @@
 #elif defined(ZYAN_POSIX)
 #   include <unistd.h>
 #   include <stdio.h>
-#   if defined(__APPLE__)
+#   if defined(ZYAN_APPLE)
 #       include <mach/mach.h>
 #       include <mach/mach_vm.h>
 #   endif
@@ -206,7 +206,7 @@ ZyanStatus ZyanMemoryVirtualQuery(const void* address, ZyanMemoryRegionInfo* inf
     info->protection = (ZyanMemoryPageProtection)mbi.Protect;
     return ZYAN_STATUS_SUCCESS;
 
-#elif defined(__linux__)
+#elif defined(ZYAN_LINUX)
 
     const ZyanUPointer target = (ZyanUPointer)address;
     FILE* const maps = fopen("/proc/self/maps", "r");
@@ -262,7 +262,7 @@ ZyanStatus ZyanMemoryVirtualQuery(const void* address, ZyanMemoryRegionInfo* inf
     }
     return ZYAN_STATUS_SUCCESS;
 
-#elif defined(__APPLE__)
+#elif defined(ZYAN_APPLE)
 
     mach_vm_address_t region_addr = (mach_vm_address_t)(ZyanUPointer)address;
     mach_vm_size_t region_size = 0;
@@ -308,6 +308,17 @@ ZyanStatus ZyanMemoryVirtualQuery(const void* address, ZyanMemoryRegionInfo* inf
     info->protection = (ZyanMemoryPageProtection)prot;
     mach_port_deallocate(mach_task_self(), object_name);
     return ZYAN_STATUS_SUCCESS;
+
+#elif defined(ZYAN_POSIX)
+
+    // Other POSIX platforms have no portable virtual-memory query primitive.
+    // The inline-hook engine only needs this on Linux and macOS.
+    ZYAN_UNUSED(address);
+    info->base       = ZYAN_NULL;
+    info->size       = 0;
+    info->state      = ZYAN_MEMORY_REGION_STATE_FREE;
+    info->protection = (ZyanMemoryPageProtection)0;
+    return ZYAN_STATUS_BAD_SYSTEMCALL;
 
 #else
 #   error "Unsupported platform detected"

--- a/src/API/Memory.c
+++ b/src/API/Memory.c
@@ -32,6 +32,14 @@
 
 #elif defined(ZYAN_POSIX)
 #   include <unistd.h>
+#   include <stdio.h>
+#   if defined(__APPLE__)
+#       include <mach/mach.h>
+#       include <mach/mach_vm.h>
+#   endif
+#   if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)
+#       define MAP_ANONYMOUS MAP_ANON
+#   endif
 #else
 #   error "Unsupported platform detected"
 #endif
@@ -123,6 +131,53 @@ ZyanStatus ZyanMemoryVirtualFree(void* address, ZyanUSize size)
 #endif
 
     return ZYAN_STATUS_SUCCESS;    
+}
+
+ZyanStatus ZyanMemoryVirtualAlloc(void** address, ZyanUSize size,
+    ZyanMemoryPageProtection protection)
+{
+    if (!address || (size == 0))
+    {
+        return ZYAN_STATUS_INVALID_ARGUMENT;
+    }
+
+#if defined(ZYAN_WINDOWS)
+
+    void* const result = VirtualAlloc(*address, size, MEM_RESERVE | MEM_COMMIT, protection);
+    if (!result)
+    {
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
+    }
+    *address = result;
+
+#elif defined(ZYAN_POSIX)
+
+    int flags = MAP_PRIVATE | MAP_ANONYMOUS;
+#if defined(MAP_FIXED_NOREPLACE)
+    if (*address)
+    {
+        flags |= MAP_FIXED_NOREPLACE;
+    }
+#endif
+
+    void* const result = mmap(*address, size, protection, flags, -1, 0);
+    if (result == MAP_FAILED)
+    {
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
+    }
+
+    // Reject rather than silently relocating when an exact base was requested but the
+    // kernel ignored the hint (e.g. a platform without `MAP_FIXED_NOREPLACE`).
+    if (*address && (result != *address))
+    {
+        munmap(result, size);
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
+    }
+    *address = result;
+
+#endif
+
+    return ZYAN_STATUS_SUCCESS;
 }
 
 /* ---------------------------------------------------------------------------------------------- */

--- a/src/API/Memory.c
+++ b/src/API/Memory.c
@@ -180,6 +180,140 @@ ZyanStatus ZyanMemoryVirtualAlloc(void** address, ZyanUSize size,
     return ZYAN_STATUS_SUCCESS;
 }
 
+ZyanStatus ZyanMemoryVirtualQuery(const void* address, ZyanMemoryRegionInfo* info)
+{
+    if (!info)
+    {
+        return ZYAN_STATUS_INVALID_ARGUMENT;
+    }
+
+#if defined(ZYAN_WINDOWS)
+
+    MEMORY_BASIC_INFORMATION mbi;
+    if (VirtualQuery(address, &mbi, sizeof(mbi)) == 0)
+    {
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
+    }
+    info->base = mbi.BaseAddress;
+    info->size = mbi.RegionSize;
+    switch (mbi.State)
+    {
+    case MEM_FREE:    info->state = ZYAN_MEMORY_REGION_STATE_FREE;      break;
+    case MEM_RESERVE: info->state = ZYAN_MEMORY_REGION_STATE_RESERVED;  break;
+    case MEM_COMMIT:  info->state = ZYAN_MEMORY_REGION_STATE_COMMITTED; break;
+    default:          info->state = ZYAN_MEMORY_REGION_STATE_FREE;      break;
+    }
+    info->protection = (ZyanMemoryPageProtection)mbi.Protect;
+    return ZYAN_STATUS_SUCCESS;
+
+#elif defined(__linux__)
+
+    const ZyanUPointer target = (ZyanUPointer)address;
+    FILE* const maps = fopen("/proc/self/maps", "r");
+    if (!maps)
+    {
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
+    }
+
+    char line[512];
+    ZyanUPointer prev_end = 0;
+    ZyanBool found = ZYAN_FALSE;
+    while (fgets(line, sizeof(line), maps))
+    {
+        unsigned long start, end;
+        char perms[5] = { 0 };
+        if (sscanf(line, "%lx-%lx %4s", &start, &end, perms) != 3)
+        {
+            continue;
+        }
+        if (target < start)
+        {
+            info->base       = (void*)prev_end;
+            info->size       = (ZyanUSize)(start - prev_end);
+            info->state      = ZYAN_MEMORY_REGION_STATE_FREE;
+            info->protection = (ZyanMemoryPageProtection)0;
+            found = ZYAN_TRUE;
+            break;
+        }
+        if (target < end)
+        {
+            int prot = 0;
+            if (perms[0] == 'r') prot |= PROT_READ;
+            if (perms[1] == 'w') prot |= PROT_WRITE;
+            if (perms[2] == 'x') prot |= PROT_EXEC;
+            info->base       = (void*)start;
+            info->size       = (ZyanUSize)(end - start);
+            info->state      = ZYAN_MEMORY_REGION_STATE_COMMITTED;
+            info->protection = (ZyanMemoryPageProtection)prot;
+            found = ZYAN_TRUE;
+            break;
+        }
+        prev_end = end;
+    }
+    fclose(maps);
+
+    if (!found)
+    {
+        // Above all mappings: free up to the top of the address space.
+        info->base       = (void*)prev_end;
+        info->size       = (ZyanUSize)(~(ZyanUPointer)0 - prev_end);
+        info->state      = ZYAN_MEMORY_REGION_STATE_FREE;
+        info->protection = (ZyanMemoryPageProtection)0;
+    }
+    return ZYAN_STATUS_SUCCESS;
+
+#elif defined(__APPLE__)
+
+    mach_vm_address_t region_addr = (mach_vm_address_t)(ZyanUPointer)address;
+    mach_vm_size_t region_size = 0;
+    vm_region_basic_info_data_64_t vinfo;
+    mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT_64;
+    mach_port_t object_name = MACH_PORT_NULL;
+
+    const kern_return_t kr = mach_vm_region(mach_task_self(), &region_addr, &region_size,
+        VM_REGION_BASIC_INFO_64, (vm_region_info_t)&vinfo, &count, &object_name);
+    if (kr == KERN_INVALID_ADDRESS)
+    {
+        info->base       = (void*)address;
+        info->size       = (ZyanUSize)(~(ZyanUPointer)0 - (ZyanUPointer)address);
+        info->state      = ZYAN_MEMORY_REGION_STATE_FREE;
+        info->protection = (ZyanMemoryPageProtection)0;
+        return ZYAN_STATUS_SUCCESS;
+    }
+    if (kr != KERN_SUCCESS)
+    {
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
+    }
+
+    // `mach_vm_region` returns the region at or above the queried address. If it starts
+    // above `address`, `address` sits in a free gap below it.
+    if ((ZyanUPointer)region_addr > (ZyanUPointer)address)
+    {
+        info->base       = (void*)address;
+        info->size       = (ZyanUSize)((ZyanUPointer)region_addr - (ZyanUPointer)address);
+        info->state      = ZYAN_MEMORY_REGION_STATE_FREE;
+        info->protection = (ZyanMemoryPageProtection)0;
+        // Release the send-right returned by mach_vm_region to avoid leaking a Mach port.
+        mach_port_deallocate(mach_task_self(), object_name);
+        return ZYAN_STATUS_SUCCESS;
+    }
+
+    int prot = 0;
+    if (vinfo.protection & VM_PROT_READ)    prot |= PROT_READ;
+    if (vinfo.protection & VM_PROT_WRITE)   prot |= PROT_WRITE;
+    if (vinfo.protection & VM_PROT_EXECUTE) prot |= PROT_EXEC;
+    info->base       = (void*)(ZyanUPointer)region_addr;
+    info->size       = (ZyanUSize)region_size;
+    info->state      = ZYAN_MEMORY_REGION_STATE_COMMITTED;
+    info->protection = (ZyanMemoryPageProtection)prot;
+    mach_port_deallocate(mach_task_self(), object_name);
+    return ZYAN_STATUS_SUCCESS;
+
+#else
+#   error "Unsupported platform detected"
+#endif
+}
+
 /* ---------------------------------------------------------------------------------------------- */
 
 /* ============================================================================================== */

--- a/src/API/Process.c
+++ b/src/API/Process.c
@@ -36,7 +36,6 @@
 #      include <windows.h>
 #endif
 #elif defined(ZYAN_POSIX)
-#   include <sys/mman.h>
 #else
 #   error "Unsupported platform detected"
 #endif
@@ -60,10 +59,12 @@ ZyanStatus ZyanProcessFlushInstructionCache(void* address, ZyanUSize size)
 
 #elif defined(ZYAN_POSIX)
 
-    if (msync(address, size, MS_SYNC | MS_INVALIDATE))
-    {
-        return ZYAN_STATUS_BAD_SYSTEMCALL;
-    }
+    // `__builtin___clear_cache` is the portable GCC/Clang primitive for flushing the instruction
+    // cache over a byte range: a no-op on coherent-icache architectures (x86) and the required
+    // cache-maintenance elsewhere (AArch64). Unlike `msync` it has no page-alignment requirement
+    // and is the correct operation for freshly written code; `msync` synchronises file-backed
+    // mappings, which is wrong here and rejects the unaligned anonymous addresses this receives.
+    __builtin___clear_cache((char*)address, (char*)address + size);
 
 #endif
 

--- a/src/API/ThreadControl.c
+++ b/src/API/ThreadControl.c
@@ -38,6 +38,10 @@
 #   include <unistd.h>
 #   include <dirent.h>
 #   include <stdlib.h>
+#   include <signal.h>
+#   include <ucontext.h>
+#   include <semaphore.h>
+#   include <string.h>
 #elif defined(ZYAN_APPLE)
 #   include <mach/mach.h>
 #   include <pthread.h>
@@ -175,5 +179,239 @@ ZyanStatus ZyanThreadEnumerate(ZyanVector* thread_ids, ZyanBool include_current)
 
 #endif
 }
+
+/* ============================================================================================== */
+/* Suspend / resume / instruction pointer                                                         */
+/* ============================================================================================== */
+
+#if defined(ZYAN_WINDOWS)
+
+ZyanStatus ZyanThreadSuspend(ZyanThreadId thread_id)
+{
+    const HANDLE handle = OpenThread(THREAD_SUSPEND_RESUME, ZYAN_FALSE, (DWORD)thread_id);
+    if (!handle)
+    {
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
+    }
+    const DWORD result = SuspendThread(handle);
+    CloseHandle(handle);
+    return (result == (DWORD)-1) ? ZYAN_STATUS_BAD_SYSTEMCALL : ZYAN_STATUS_SUCCESS;
+}
+
+ZyanStatus ZyanThreadResume(ZyanThreadId thread_id)
+{
+    const HANDLE handle = OpenThread(THREAD_SUSPEND_RESUME, ZYAN_FALSE, (DWORD)thread_id);
+    if (!handle)
+    {
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
+    }
+    const DWORD result = ResumeThread(handle);
+    CloseHandle(handle);
+    return (result == (DWORD)-1) ? ZYAN_STATUS_BAD_SYSTEMCALL : ZYAN_STATUS_SUCCESS;
+}
+
+#elif defined(ZYAN_LINUX)
+
+// The suspend signal parks the target thread inside its handler until it is resumed, exposing and
+// optionally rewriting the thread's instruction pointer. A dedicated realtime signal is used so it
+// does not collide with application signal handlers. Suspends are serialised by the caller.
+#define ZYAN_THREAD_CONTROL_SIGNAL (SIGRTMIN + 6)
+
+typedef struct ZyanThreadParkSlot_
+{
+    volatile pid_t        tid;
+    volatile int          active;
+    sem_t                 parked;   // handler -> controller: "I am parked, saved_ip is valid"
+    sem_t                 resume;   // controller -> handler: "resume now"
+    sem_t                 done;     // handler -> controller: "I applied new_ip and am returning"
+    volatile ZyanUPointer saved_ip;
+    volatile ZyanUPointer new_ip;
+    volatile int          apply_ip;
+} ZyanThreadParkSlot;
+
+// Array of stable slot pointers. The pointer array may be reallocated, but individual slots never
+// move, so a handler parked on its slot pointer is never invalidated.
+static ZyanThreadParkSlot** g_slots = ZYAN_NULL;
+static ZyanUSize g_slot_count = 0;
+static ZyanUSize g_slot_capacity = 0;
+static volatile int g_handler_installed = 0;
+
+static pid_t ZyanGetTid(void)
+{
+    return (pid_t)syscall(SYS_gettid);
+}
+
+static ZyanThreadParkSlot* ZyanFindSlot(pid_t tid)
+{
+    for (ZyanUSize i = 0; i < g_slot_count; ++i)
+    {
+        if (g_slots[i]->active && (g_slots[i]->tid == tid))
+        {
+            return g_slots[i];
+        }
+    }
+    return ZYAN_NULL;
+}
+
+static void ZyanThreadControlHandler(int sig, siginfo_t* info, void* ucontext)
+{
+    ZYAN_UNUSED(sig);
+    ZYAN_UNUSED(info);
+
+    ZyanThreadParkSlot* const slot = ZyanFindSlot(ZyanGetTid());
+    if (!slot)
+    {
+        return; // spurious delivery for a thread we are not parking
+    }
+
+    ucontext_t* const uc = (ucontext_t*)ucontext;
+    slot->saved_ip = (ZyanUPointer)uc->uc_mcontext.gregs[REG_RIP];
+    sem_post(&slot->parked);
+
+    while (sem_wait(&slot->resume) != 0)
+    {
+        // retry on EINTR
+    }
+
+    if (slot->apply_ip)
+    {
+        uc->uc_mcontext.gregs[REG_RIP] = (greg_t)slot->new_ip;
+    }
+    sem_post(&slot->done);
+}
+
+static ZyanStatus ZyanThreadControlEnsureHandler(void)
+{
+    if (g_handler_installed)
+    {
+        return ZYAN_STATUS_SUCCESS;
+    }
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_sigaction = &ZyanThreadControlHandler;
+    sa.sa_flags = SA_SIGINFO | SA_RESTART;
+    sigfillset(&sa.sa_mask);
+    if (sigaction(ZYAN_THREAD_CONTROL_SIGNAL, &sa, ZYAN_NULL) != 0)
+    {
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
+    }
+    g_handler_installed = 1;
+    return ZYAN_STATUS_SUCCESS;
+}
+
+static ZyanThreadParkSlot* ZyanAcquireSlot(void)
+{
+    for (ZyanUSize i = 0; i < g_slot_count; ++i)
+    {
+        if (!g_slots[i]->active)
+        {
+            return g_slots[i];
+        }
+    }
+    if (g_slot_count == g_slot_capacity)
+    {
+        const ZyanUSize new_cap = g_slot_capacity ? (g_slot_capacity * 2) : 8;
+        ZyanThreadParkSlot** const grown =
+            (ZyanThreadParkSlot**)realloc(g_slots, new_cap * sizeof(ZyanThreadParkSlot*));
+        if (!grown)
+        {
+            return ZYAN_NULL;
+        }
+        g_slots = grown;
+        g_slot_capacity = new_cap;
+    }
+    ZyanThreadParkSlot* const slot = (ZyanThreadParkSlot*)malloc(sizeof(ZyanThreadParkSlot));
+    if (!slot)
+    {
+        return ZYAN_NULL;
+    }
+    memset(slot, 0, sizeof(*slot));
+    if ((sem_init(&slot->parked, 0, 0) != 0) ||
+        (sem_init(&slot->resume, 0, 0) != 0) ||
+        (sem_init(&slot->done, 0, 0) != 0))
+    {
+        free(slot);
+        return ZYAN_NULL;
+    }
+    g_slots[g_slot_count++] = slot;
+    return slot;
+}
+
+ZyanStatus ZyanThreadSuspend(ZyanThreadId thread_id)
+{
+    ZYAN_CHECK(ZyanThreadControlEnsureHandler());
+
+    ZyanThreadParkSlot* const slot = ZyanAcquireSlot();
+    if (!slot)
+    {
+        return ZYAN_STATUS_NOT_ENOUGH_MEMORY;
+    }
+
+    slot->tid      = (pid_t)thread_id;
+    slot->saved_ip = 0;
+    slot->new_ip   = 0;
+    slot->apply_ip = 0;
+    slot->active   = 1;               // publish before signalling
+    __sync_synchronize();
+
+    if (syscall(SYS_tgkill, getpid(), (pid_t)thread_id, ZYAN_THREAD_CONTROL_SIGNAL) != 0)
+    {
+        slot->active = 0;
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
+    }
+
+    while (sem_wait(&slot->parked) != 0)
+    {
+        // retry on EINTR
+    }
+    return ZYAN_STATUS_SUCCESS;
+}
+
+ZyanStatus ZyanThreadResume(ZyanThreadId thread_id)
+{
+    ZyanThreadParkSlot* const slot = ZyanFindSlot((pid_t)thread_id);
+    if (!slot)
+    {
+        return ZYAN_STATUS_INVALID_ARGUMENT;
+    }
+
+    sem_post(&slot->resume);
+    while (sem_wait(&slot->done) != 0)
+    {
+        // retry on EINTR
+    }
+    slot->active = 0;                 // free the slot for reuse only after the handler returned
+    return ZYAN_STATUS_SUCCESS;
+}
+
+#elif defined(ZYAN_APPLE)
+
+ZyanStatus ZyanThreadSuspend(ZyanThreadId thread_id)
+{
+    return (thread_suspend((thread_act_t)thread_id) == KERN_SUCCESS)
+        ? ZYAN_STATUS_SUCCESS : ZYAN_STATUS_BAD_SYSTEMCALL;
+}
+
+ZyanStatus ZyanThreadResume(ZyanThreadId thread_id)
+{
+    return (thread_resume((thread_act_t)thread_id) == KERN_SUCCESS)
+        ? ZYAN_STATUS_SUCCESS : ZYAN_STATUS_BAD_SYSTEMCALL;
+}
+
+#elif defined(ZYAN_POSIX)
+
+ZyanStatus ZyanThreadSuspend(ZyanThreadId thread_id)
+{
+    ZYAN_UNUSED(thread_id);
+    return ZYAN_STATUS_BAD_SYSTEMCALL;
+}
+
+ZyanStatus ZyanThreadResume(ZyanThreadId thread_id)
+{
+    ZYAN_UNUSED(thread_id);
+    return ZYAN_STATUS_BAD_SYSTEMCALL;
+}
+
+#endif
 
 #endif /* ZYAN_NO_LIBC */

--- a/src/API/ThreadControl.c
+++ b/src/API/ThreadControl.c
@@ -1,0 +1,179 @@
+/***************************************************************************************************
+
+  Zyan Core Library (Zycore-C)
+
+  Original Author : Florian Bernd
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+
+***************************************************************************************************/
+
+#include <Zycore/API/Thread.h>
+#include <Zycore/LibC.h>
+#include <Zycore/Vector.h>
+
+#ifndef ZYAN_NO_LIBC
+
+#if defined(ZYAN_WINDOWS)
+#   include <windows.h>
+#   include <tlhelp32.h>
+#elif defined(ZYAN_LINUX)
+#   include <sys/syscall.h>
+#   include <unistd.h>
+#   include <dirent.h>
+#   include <stdlib.h>
+#elif defined(ZYAN_APPLE)
+#   include <mach/mach.h>
+#   include <pthread.h>
+#elif defined(ZYAN_POSIX)
+    // Other POSIX platforms are not supported by the thread-control API.
+#else
+#   error "Unsupported platform detected"
+#endif
+
+/* ============================================================================================== */
+/* Enumeration                                                                                     */
+/* ============================================================================================== */
+
+ZyanStatus ZyanThreadEnumerate(ZyanVector* thread_ids, ZyanBool include_current)
+{
+    if (!thread_ids)
+    {
+        return ZYAN_STATUS_INVALID_ARGUMENT;
+    }
+
+#if defined(ZYAN_WINDOWS)
+
+    const DWORD pid = GetCurrentProcessId();
+    const DWORD self = GetCurrentThreadId();
+    const HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
+    if (snapshot == INVALID_HANDLE_VALUE)
+    {
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
+    }
+
+    THREADENTRY32 entry;
+    ZYAN_MEMSET(&entry, 0, sizeof(entry));
+    entry.dwSize = sizeof(entry);
+
+    ZyanStatus status = ZYAN_STATUS_SUCCESS;
+    if (Thread32First(snapshot, &entry))
+    {
+        do
+        {
+            if (entry.th32OwnerProcessID != pid)
+            {
+                continue;
+            }
+            if (!include_current && (entry.th32ThreadID == self))
+            {
+                continue;
+            }
+            const ZyanThreadId id = (ZyanThreadId)entry.th32ThreadID;
+            status = ZyanVectorPushBack(thread_ids, &id);
+            if (!ZYAN_SUCCESS(status))
+            {
+                break;
+            }
+        } while (Thread32Next(snapshot, &entry));
+    }
+    CloseHandle(snapshot);
+    return status;
+
+#elif defined(ZYAN_LINUX)
+
+    const pid_t self = (pid_t)syscall(SYS_gettid);
+    DIR* const dir = opendir("/proc/self/task");
+    if (!dir)
+    {
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
+    }
+
+    ZyanStatus status = ZYAN_STATUS_SUCCESS;
+    struct dirent* ent;
+    while ((ent = readdir(dir)) != ZYAN_NULL)
+    {
+        if ((ent->d_name[0] == '.') &&
+            ((ent->d_name[1] == '\0') || ((ent->d_name[1] == '.') && (ent->d_name[2] == '\0'))))
+        {
+            continue;
+        }
+        const long tid = strtol(ent->d_name, ZYAN_NULL, 10);
+        if (tid <= 0)
+        {
+            continue;
+        }
+        if (!include_current && ((pid_t)tid == self))
+        {
+            continue;
+        }
+        const ZyanThreadId id = (ZyanThreadId)tid;
+        status = ZyanVectorPushBack(thread_ids, &id);
+        if (!ZYAN_SUCCESS(status))
+        {
+            break;
+        }
+    }
+    closedir(dir);
+    return status;
+
+#elif defined(ZYAN_APPLE)
+
+    const thread_act_t self = mach_thread_self();
+    thread_act_array_t threads;
+    mach_msg_type_number_t thread_count = 0;
+    if (task_threads(mach_task_self(), &threads, &thread_count) != KERN_SUCCESS)
+    {
+        mach_port_deallocate(mach_task_self(), self);
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
+    }
+
+    ZyanStatus status = ZYAN_STATUS_SUCCESS;
+    for (mach_msg_type_number_t i = 0; i < thread_count; ++i)
+    {
+        if (!include_current && (threads[i] == self))
+        {
+            mach_port_deallocate(mach_task_self(), threads[i]);
+            continue;
+        }
+        const ZyanThreadId id = (ZyanThreadId)threads[i];
+        status = ZyanVectorPushBack(thread_ids, &id);
+        if (!ZYAN_SUCCESS(status))
+        {
+            // Release the remaining ports we will not hand back.
+            for (mach_msg_type_number_t j = i; j < thread_count; ++j)
+            {
+                mach_port_deallocate(mach_task_self(), threads[j]);
+            }
+            break;
+        }
+    }
+    mach_port_deallocate(mach_task_self(), self);
+    vm_deallocate(mach_task_self(), (vm_address_t)threads, thread_count * sizeof(thread_act_t));
+    return status;
+
+#elif defined(ZYAN_POSIX)
+
+    ZYAN_UNUSED(include_current);
+    return ZYAN_STATUS_BAD_SYSTEMCALL;
+
+#endif
+}
+
+#endif /* ZYAN_NO_LIBC */

--- a/src/API/ThreadControl.c
+++ b/src/API/ThreadControl.c
@@ -216,6 +216,7 @@ ZyanStatus ZyanThreadGetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer*
     {
         return ZYAN_STATUS_INVALID_ARGUMENT;
     }
+#if defined(ZYAN_X64) || defined(ZYAN_X86)
     const HANDLE handle = OpenThread(THREAD_GET_CONTEXT, ZYAN_FALSE, (DWORD)thread_id);
     if (!handle)
     {
@@ -230,16 +231,23 @@ ZyanStatus ZyanThreadGetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer*
     {
         return ZYAN_STATUS_BAD_SYSTEMCALL;
     }
-#if defined(ZYAN_X64)
+#   if defined(ZYAN_X64)
     *ip = (ZyanUPointer)context.Rip;
-#else
+#   else
     *ip = (ZyanUPointer)context.Eip;
-#endif
+#   endif
     return ZYAN_STATUS_SUCCESS;
+#else
+    // Register access is only implemented for x86-64 (and x86) this round.
+    ZYAN_UNUSED(thread_id);
+    ZYAN_UNUSED(ip);
+    return ZYAN_STATUS_BAD_SYSTEMCALL;
+#endif
 }
 
 ZyanStatus ZyanThreadSetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer ip)
 {
+#if defined(ZYAN_X64) || defined(ZYAN_X86)
     const HANDLE handle = OpenThread(THREAD_GET_CONTEXT | THREAD_SET_CONTEXT, ZYAN_FALSE,
         (DWORD)thread_id);
     if (!handle)
@@ -254,14 +262,20 @@ ZyanStatus ZyanThreadSetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer 
         CloseHandle(handle);
         return ZYAN_STATUS_BAD_SYSTEMCALL;
     }
-#if defined(ZYAN_X64)
+#   if defined(ZYAN_X64)
     context.Rip = (DWORD64)ip;
-#else
+#   else
     context.Eip = (DWORD)ip;
-#endif
+#   endif
     const BOOL ok = SetThreadContext(handle, &context);
     CloseHandle(handle);
     return ok ? ZYAN_STATUS_SUCCESS : ZYAN_STATUS_BAD_SYSTEMCALL;
+#else
+    // Register access is only implemented for x86-64 (and x86) this round.
+    ZYAN_UNUSED(thread_id);
+    ZYAN_UNUSED(ip);
+    return ZYAN_STATUS_BAD_SYSTEMCALL;
+#endif
 }
 
 #elif defined(ZYAN_LINUX)
@@ -492,6 +506,7 @@ ZyanStatus ZyanThreadGetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer*
     {
         return ZYAN_STATUS_INVALID_ARGUMENT;
     }
+#if defined(ZYAN_X64)
     x86_thread_state64_t state;
     mach_msg_type_number_t count = x86_THREAD_STATE64_COUNT;
     if (thread_get_state((thread_act_t)thread_id, x86_THREAD_STATE64,
@@ -501,10 +516,17 @@ ZyanStatus ZyanThreadGetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer*
     }
     *ip = (ZyanUPointer)state.__rip;
     return ZYAN_STATUS_SUCCESS;
+#else
+    // Register access is only implemented for x86-64 this round.
+    ZYAN_UNUSED(thread_id);
+    ZYAN_UNUSED(ip);
+    return ZYAN_STATUS_BAD_SYSTEMCALL;
+#endif
 }
 
 ZyanStatus ZyanThreadSetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer ip)
 {
+#if defined(ZYAN_X64)
     x86_thread_state64_t state;
     mach_msg_type_number_t count = x86_THREAD_STATE64_COUNT;
     if (thread_get_state((thread_act_t)thread_id, x86_THREAD_STATE64,
@@ -519,6 +541,12 @@ ZyanStatus ZyanThreadSetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer 
         return ZYAN_STATUS_BAD_SYSTEMCALL;
     }
     return ZYAN_STATUS_SUCCESS;
+#else
+    // Register access is only implemented for x86-64 this round.
+    ZYAN_UNUSED(thread_id);
+    ZYAN_UNUSED(ip);
+    return ZYAN_STATUS_BAD_SYSTEMCALL;
+#endif
 }
 
 #elif defined(ZYAN_POSIX)

--- a/src/API/ThreadControl.c
+++ b/src/API/ThreadControl.c
@@ -231,9 +231,16 @@ typedef struct ZyanThreadParkSlot_
 
 // Array of stable slot pointers. The pointer array may be reallocated, but individual slots never
 // move, so a handler parked on its slot pointer is never invalidated.
+//
+// These globals are written by the controller thread (ZyanAcquireSlot) and read by the target
+// thread's signal handler (ZyanFindSlot). `tgkill` entering the kernel and the subsequent signal
+// delivery provide the memory barrier that publishes the controller's writes to the handler; that
+// is the same ordering guarantee other signal-based thread-stop implementations rely on. Suspends
+// are serialised by a single controller thread, so there are no concurrent writers. `volatile`
+// additionally prevents the compiler from caching the loop bound, matching the per-slot fields.
 static ZyanThreadParkSlot** g_slots = ZYAN_NULL;
-static ZyanUSize g_slot_count = 0;
-static ZyanUSize g_slot_capacity = 0;
+static volatile ZyanUSize g_slot_count = 0;
+static volatile ZyanUSize g_slot_capacity = 0;
 static volatile int g_handler_installed = 0;
 
 static pid_t ZyanGetTid(void)

--- a/src/API/ThreadControl.c
+++ b/src/API/ThreadControl.c
@@ -42,6 +42,8 @@
 #   include <ucontext.h>
 #   include <semaphore.h>
 #   include <string.h>
+#   include <time.h>
+#   include <errno.h>
 #elif defined(ZYAN_APPLE)
 #   include <mach/mach.h>
 #   include <pthread.h>
@@ -441,9 +443,27 @@ ZyanStatus ZyanThreadSuspend(ZyanThreadId thread_id)
         return ZYAN_STATUS_BAD_SYSTEMCALL;
     }
 
-    while (sem_wait(&slot->parked) != 0)
+    // Wait for the target to park in the signal handler, but bounded: if the thread never runs the
+    // handler (for example, it is exiting, so the signal is dropped), an unbounded wait would
+    // deadlock. A live thread parks within microseconds, so a multi-second timeout reliably
+    // distinguishes a parked thread from an unresponsive one, which is retired and reported as a
+    // failed suspend so the caller can skip it.
+    struct timespec deadline;
+    if (clock_gettime(CLOCK_REALTIME, &deadline) != 0)
     {
-        // retry on EINTR
+        slot->active = 0;
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
+    }
+    deadline.tv_sec += 5;
+
+    while (sem_timedwait(&slot->parked, &deadline) != 0)
+    {
+        if (errno == EINTR)
+        {
+            continue;
+        }
+        slot->active = 0;
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
     }
     return ZYAN_STATUS_SUCCESS;
 }

--- a/src/API/ThreadControl.c
+++ b/src/API/ThreadControl.c
@@ -210,6 +210,60 @@ ZyanStatus ZyanThreadResume(ZyanThreadId thread_id)
     return (result == (DWORD)-1) ? ZYAN_STATUS_BAD_SYSTEMCALL : ZYAN_STATUS_SUCCESS;
 }
 
+ZyanStatus ZyanThreadGetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer* ip)
+{
+    if (!ip)
+    {
+        return ZYAN_STATUS_INVALID_ARGUMENT;
+    }
+    const HANDLE handle = OpenThread(THREAD_GET_CONTEXT, ZYAN_FALSE, (DWORD)thread_id);
+    if (!handle)
+    {
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
+    }
+    CONTEXT context;
+    ZYAN_MEMSET(&context, 0, sizeof(context));
+    context.ContextFlags = CONTEXT_CONTROL;
+    const BOOL ok = GetThreadContext(handle, &context);
+    CloseHandle(handle);
+    if (!ok)
+    {
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
+    }
+#if defined(ZYAN_X64)
+    *ip = (ZyanUPointer)context.Rip;
+#else
+    *ip = (ZyanUPointer)context.Eip;
+#endif
+    return ZYAN_STATUS_SUCCESS;
+}
+
+ZyanStatus ZyanThreadSetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer ip)
+{
+    const HANDLE handle = OpenThread(THREAD_GET_CONTEXT | THREAD_SET_CONTEXT, ZYAN_FALSE,
+        (DWORD)thread_id);
+    if (!handle)
+    {
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
+    }
+    CONTEXT context;
+    ZYAN_MEMSET(&context, 0, sizeof(context));
+    context.ContextFlags = CONTEXT_CONTROL;
+    if (!GetThreadContext(handle, &context))
+    {
+        CloseHandle(handle);
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
+    }
+#if defined(ZYAN_X64)
+    context.Rip = (DWORD64)ip;
+#else
+    context.Eip = (DWORD)ip;
+#endif
+    const BOOL ok = SetThreadContext(handle, &context);
+    CloseHandle(handle);
+    return ok ? ZYAN_STATUS_SUCCESS : ZYAN_STATUS_BAD_SYSTEMCALL;
+}
+
 #elif defined(ZYAN_LINUX)
 
 // The suspend signal parks the target thread inside its handler until it is resumed, exposing and
@@ -391,6 +445,33 @@ ZyanStatus ZyanThreadResume(ZyanThreadId thread_id)
     return ZYAN_STATUS_SUCCESS;
 }
 
+ZyanStatus ZyanThreadGetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer* ip)
+{
+    if (!ip)
+    {
+        return ZYAN_STATUS_INVALID_ARGUMENT;
+    }
+    ZyanThreadParkSlot* const slot = ZyanFindSlot((pid_t)thread_id);
+    if (!slot)
+    {
+        return ZYAN_STATUS_INVALID_ARGUMENT;
+    }
+    *ip = slot->saved_ip;
+    return ZYAN_STATUS_SUCCESS;
+}
+
+ZyanStatus ZyanThreadSetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer ip)
+{
+    ZyanThreadParkSlot* const slot = ZyanFindSlot((pid_t)thread_id);
+    if (!slot)
+    {
+        return ZYAN_STATUS_INVALID_ARGUMENT;
+    }
+    slot->new_ip = ip;
+    slot->apply_ip = 1;
+    return ZYAN_STATUS_SUCCESS;
+}
+
 #elif defined(ZYAN_APPLE)
 
 ZyanStatus ZyanThreadSuspend(ZyanThreadId thread_id)
@@ -405,6 +486,41 @@ ZyanStatus ZyanThreadResume(ZyanThreadId thread_id)
         ? ZYAN_STATUS_SUCCESS : ZYAN_STATUS_BAD_SYSTEMCALL;
 }
 
+ZyanStatus ZyanThreadGetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer* ip)
+{
+    if (!ip)
+    {
+        return ZYAN_STATUS_INVALID_ARGUMENT;
+    }
+    x86_thread_state64_t state;
+    mach_msg_type_number_t count = x86_THREAD_STATE64_COUNT;
+    if (thread_get_state((thread_act_t)thread_id, x86_THREAD_STATE64,
+        (thread_state_t)&state, &count) != KERN_SUCCESS)
+    {
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
+    }
+    *ip = (ZyanUPointer)state.__rip;
+    return ZYAN_STATUS_SUCCESS;
+}
+
+ZyanStatus ZyanThreadSetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer ip)
+{
+    x86_thread_state64_t state;
+    mach_msg_type_number_t count = x86_THREAD_STATE64_COUNT;
+    if (thread_get_state((thread_act_t)thread_id, x86_THREAD_STATE64,
+        (thread_state_t)&state, &count) != KERN_SUCCESS)
+    {
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
+    }
+    state.__rip = (uint64_t)ip;
+    if (thread_set_state((thread_act_t)thread_id, x86_THREAD_STATE64,
+        (thread_state_t)&state, x86_THREAD_STATE64_COUNT) != KERN_SUCCESS)
+    {
+        return ZYAN_STATUS_BAD_SYSTEMCALL;
+    }
+    return ZYAN_STATUS_SUCCESS;
+}
+
 #elif defined(ZYAN_POSIX)
 
 ZyanStatus ZyanThreadSuspend(ZyanThreadId thread_id)
@@ -416,6 +532,20 @@ ZyanStatus ZyanThreadSuspend(ZyanThreadId thread_id)
 ZyanStatus ZyanThreadResume(ZyanThreadId thread_id)
 {
     ZYAN_UNUSED(thread_id);
+    return ZYAN_STATUS_BAD_SYSTEMCALL;
+}
+
+ZyanStatus ZyanThreadGetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer* ip)
+{
+    ZYAN_UNUSED(thread_id);
+    ZYAN_UNUSED(ip);
+    return ZYAN_STATUS_BAD_SYSTEMCALL;
+}
+
+ZyanStatus ZyanThreadSetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer ip)
+{
+    ZYAN_UNUSED(thread_id);
+    ZYAN_UNUSED(ip);
     return ZYAN_STATUS_BAD_SYSTEMCALL;
 }
 

--- a/src/API/ThreadControl.c
+++ b/src/API/ThreadControl.c
@@ -340,7 +340,9 @@ static void ZyanThreadControlHandler(int sig, siginfo_t* info, void* ucontext)
     }
 
     ucontext_t* const uc = (ucontext_t*)ucontext;
+#if defined(ZYAN_X64)
     slot->saved_ip = (ZyanUPointer)uc->uc_mcontext.gregs[REG_RIP];
+#endif
     sem_post(&slot->parked);
 
     while (sem_wait(&slot->resume) != 0)
@@ -350,7 +352,11 @@ static void ZyanThreadControlHandler(int sig, siginfo_t* info, void* ucontext)
 
     if (slot->apply_ip)
     {
+#if defined(ZYAN_X64)
         uc->uc_mcontext.gregs[REG_RIP] = (greg_t)slot->new_ip;
+#else
+        ZYAN_UNUSED(uc);
+#endif
     }
     sem_post(&slot->done);
 }
@@ -461,6 +467,7 @@ ZyanStatus ZyanThreadResume(ZyanThreadId thread_id)
 
 ZyanStatus ZyanThreadGetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer* ip)
 {
+#if defined(ZYAN_X64)
     if (!ip)
     {
         return ZYAN_STATUS_INVALID_ARGUMENT;
@@ -472,10 +479,16 @@ ZyanStatus ZyanThreadGetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer*
     }
     *ip = slot->saved_ip;
     return ZYAN_STATUS_SUCCESS;
+#else
+    ZYAN_UNUSED(thread_id);
+    ZYAN_UNUSED(ip);
+    return ZYAN_STATUS_BAD_SYSTEMCALL;
+#endif
 }
 
 ZyanStatus ZyanThreadSetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer ip)
 {
+#if defined(ZYAN_X64)
     ZyanThreadParkSlot* const slot = ZyanFindSlot((pid_t)thread_id);
     if (!slot)
     {
@@ -484,6 +497,11 @@ ZyanStatus ZyanThreadSetInstructionPointer(ZyanThreadId thread_id, ZyanUPointer 
     slot->new_ip = ip;
     slot->apply_ip = 1;
     return ZYAN_STATUS_SUCCESS;
+#else
+    ZYAN_UNUSED(thread_id);
+    ZYAN_UNUSED(ip);
+    return ZYAN_STATUS_BAD_SYSTEMCALL;
+#endif
 }
 
 #elif defined(ZYAN_APPLE)

--- a/tests/Memory.cpp
+++ b/tests/Memory.cpp
@@ -52,6 +52,40 @@ TEST(MemoryTest, VirtualAllocFreeRoundtrip)
     EXPECT_EQ(ZyanMemoryVirtualFree(address, 0x1000), ZYAN_STATUS_SUCCESS);
 }
 
+TEST(MemoryTest, VirtualQueryReportsCommittedRegion)
+{
+    void* address = ZYAN_NULL;
+    ASSERT_EQ(ZyanMemoryVirtualAlloc(&address, 0x1000, ZYAN_PAGE_READWRITE),
+        ZYAN_STATUS_SUCCESS);
+
+    ZyanMemoryRegionInfo info;
+    ASSERT_EQ(ZyanMemoryVirtualQuery(address, &info), ZYAN_STATUS_SUCCESS);
+    EXPECT_EQ(info.state, ZYAN_MEMORY_REGION_STATE_COMMITTED);
+    EXPECT_LE(reinterpret_cast<ZyanUPointer>(info.base),
+              reinterpret_cast<ZyanUPointer>(address));
+    EXPECT_GE(reinterpret_cast<ZyanUPointer>(info.base) + info.size,
+              reinterpret_cast<ZyanUPointer>(address) + 0x1000);
+
+    ZyanMemoryVirtualFree(address, 0x1000);
+}
+
+TEST(MemoryTest, VirtualQueryReportsFreeRegion)
+{
+    // Allocate then free to obtain an address that is very likely unmapped afterwards.
+    void* address = ZYAN_NULL;
+    ASSERT_EQ(ZyanMemoryVirtualAlloc(&address, 0x1000, ZYAN_PAGE_READWRITE),
+        ZYAN_STATUS_SUCCESS);
+    ASSERT_EQ(ZyanMemoryVirtualFree(address, 0x1000), ZYAN_STATUS_SUCCESS);
+
+    ZyanMemoryRegionInfo info;
+    ASSERT_EQ(ZyanMemoryVirtualQuery(address, &info), ZYAN_STATUS_SUCCESS);
+    EXPECT_EQ(info.state, ZYAN_MEMORY_REGION_STATE_FREE);
+    EXPECT_LE(reinterpret_cast<ZyanUPointer>(info.base),
+              reinterpret_cast<ZyanUPointer>(address));
+    EXPECT_GT(reinterpret_cast<ZyanUPointer>(info.base) + info.size,
+              reinterpret_cast<ZyanUPointer>(address));
+}
+
 /* ============================================================================================== */
 /* Entry point                                                                                    */
 /* ============================================================================================== */

--- a/tests/Memory.cpp
+++ b/tests/Memory.cpp
@@ -86,6 +86,19 @@ TEST(MemoryTest, VirtualQueryReportsFreeRegion)
               reinterpret_cast<ZyanUPointer>(address));
 }
 
+TEST(MemoryTest, VirtualAllocFixedFailsWhenOccupied)
+{
+    void* address = ZYAN_NULL;
+    ASSERT_EQ(ZyanMemoryVirtualAlloc(&address, 0x1000, ZYAN_PAGE_READWRITE),
+        ZYAN_STATUS_SUCCESS);
+
+    void* occupied = address; // same, now-mapped base
+    EXPECT_NE(ZyanMemoryVirtualAlloc(&occupied, 0x1000, ZYAN_PAGE_READWRITE),
+        ZYAN_STATUS_SUCCESS);
+
+    ZyanMemoryVirtualFree(address, 0x1000);
+}
+
 /* ============================================================================================== */
 /* Entry point                                                                                    */
 /* ============================================================================================== */

--- a/tests/Memory.cpp
+++ b/tests/Memory.cpp
@@ -1,0 +1,65 @@
+/***************************************************************************************************
+
+  Zyan Core Library (Zycore-C)
+
+  Original Author : Florian Bernd
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+
+***************************************************************************************************/
+
+/**
+ * @file
+ * @brief   Tests the virtual-memory API.
+ */
+
+#include <gtest/gtest.h>
+#include <Zycore/API/Memory.h>
+
+/* ============================================================================================== */
+/* Tests                                                                                          */
+/* ============================================================================================== */
+
+TEST(MemoryTest, VirtualAllocFreeRoundtrip)
+{
+    void* address = ZYAN_NULL;
+    ASSERT_EQ(ZyanMemoryVirtualAlloc(&address, 0x1000, ZYAN_PAGE_READWRITE),
+        ZYAN_STATUS_SUCCESS);
+    ASSERT_NE(address, ZYAN_NULL);
+
+    volatile ZyanU8* const bytes = static_cast<ZyanU8*>(address);
+    bytes[0]        = 0x42;
+    bytes[0x1000-1] = 0x37;
+    EXPECT_EQ(bytes[0], 0x42);
+    EXPECT_EQ(bytes[0x1000-1], 0x37);
+
+    EXPECT_EQ(ZyanMemoryVirtualFree(address, 0x1000), ZYAN_STATUS_SUCCESS);
+}
+
+/* ============================================================================================== */
+/* Entry point                                                                                    */
+/* ============================================================================================== */
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+
+/* ============================================================================================== */

--- a/tests/ThreadControl.cpp
+++ b/tests/ThreadControl.cpp
@@ -1,0 +1,79 @@
+/***************************************************************************************************
+
+  Zyan Core Library (Zycore-C)
+
+  Original Author : Florian Bernd
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+
+***************************************************************************************************/
+
+/**
+ * @file
+ * @brief   Tests the thread-control API.
+ */
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <thread>
+#include <Zycore/API/Thread.h>
+#include <Zycore/Vector.h>
+
+TEST(ThreadControlTest, EnumerateFindsSpawnedThreadsAndExcludesCurrent)
+{
+    std::atomic<bool> stop{false};
+    std::atomic<int>  ready{0};
+    auto worker = [&]() { ++ready; while (!stop.load()) { std::this_thread::yield(); } };
+
+    std::thread t1(worker), t2(worker), t3(worker);
+    while (ready.load() < 3) { std::this_thread::yield(); }
+
+    ZyanVector ids;
+    ASSERT_EQ(ZyanVectorInit(&ids, sizeof(ZyanThreadId), 16,
+        reinterpret_cast<ZyanMemberProcedure>(ZYAN_NULL)), ZYAN_STATUS_SUCCESS);
+    ASSERT_EQ(ZyanThreadEnumerate(&ids, ZYAN_FALSE), ZYAN_STATUS_SUCCESS);
+
+    ZyanUSize count = 0;
+    ASSERT_EQ(ZyanVectorGetSize(&ids, &count), ZYAN_STATUS_SUCCESS);
+    // At least the three workers (main thread excluded); gtest may run more.
+    EXPECT_GE(count, static_cast<ZyanUSize>(3));
+
+    // The current thread's id must not appear when excluded.
+    ZyanThreadId self;
+    ASSERT_EQ(ZyanThreadGetCurrentThreadId(&self), ZYAN_STATUS_SUCCESS);
+
+    ZyanVector ids_incl;
+    ASSERT_EQ(ZyanVectorInit(&ids_incl, sizeof(ZyanThreadId), 16,
+        reinterpret_cast<ZyanMemberProcedure>(ZYAN_NULL)), ZYAN_STATUS_SUCCESS);
+    ASSERT_EQ(ZyanThreadEnumerate(&ids_incl, ZYAN_TRUE), ZYAN_STATUS_SUCCESS);
+    ZyanUSize count_incl = 0;
+    ASSERT_EQ(ZyanVectorGetSize(&ids_incl, &count_incl), ZYAN_STATUS_SUCCESS);
+    EXPECT_EQ(count_incl, count + 1);
+
+    stop.store(true);
+    t1.join(); t2.join(); t3.join();
+    ZyanVectorDestroy(&ids);
+    ZyanVectorDestroy(&ids_incl);
+}
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/ThreadControl.cpp
+++ b/tests/ThreadControl.cpp
@@ -132,33 +132,25 @@ TEST(ThreadControlTest, SuspendStopsProgressResumeContinues)
 // Only used by the labels-as-values based spin target below, so the whole block is guarded to
 // avoid unused-variable warnings on compilers that fall into the GTEST_SKIP path.
 #if defined(ZYAN_GNUC)
-static std::atomic<bool>      g_ip_stop{false};
-static std::atomic<bool>      g_ip_reached_end{false};
-static void*                  g_after_addr = nullptr;
-static std::atomic<bool>      g_ip_running{false};
-
-// Two known-safe redirect points within the spin loop: the top of the loop (before the atomic
-// call) and right after `load()` returns. `atomic<bool>::load` is not guaranteed to compile to a
-// single instruction, so a suspend can land inside that call; redirecting RIP away from there
-// would abandon the call's stack frame. The test below retries until it catches the worker at
-// one of these two points, where the stack is guaranteed to match IpSpinTarget's own frame.
-static void*                  g_loop_addr = nullptr;
-static void*                  g_safe_after_load_addr = nullptr;
+// g_ip_stop and g_ip_reached_end are intentionally `volatile bool`, not std::atomic: the spin
+// loop's condition must compile to an inline memory read with NO function call, so that whenever
+// the worker is suspended its instruction pointer is inside IpSpinTarget's own stack frame. That
+// is what makes redirecting the IP to `after_loop` (a same-frame jump) stack-safe. An atomic load
+// can compile to a real call, and suspending the worker inside that call would corrupt its stack
+// when the IP is redirected away.
+static volatile bool     g_ip_stop = false;
+static volatile bool     g_ip_reached_end = false;
+static void*             g_after_addr = nullptr;
+static std::atomic<bool> g_ip_running{false};
 
 static void IpSpinTarget()
 {
     g_after_addr = &&after_loop;      // GCC/Clang labels-as-values extension
-    g_loop_addr = &&loop;
-    g_safe_after_load_addr = &&safe_after_load;
     g_ip_running.store(true);
 loop:
-    {
-        const bool stop = g_ip_stop.load();
-    safe_after_load:
-        if (!stop) { goto loop; }
-    }
+    if (!g_ip_stop) { goto loop; }
 after_loop:
-    g_ip_reached_end.store(true);
+    g_ip_reached_end = true;
 }
 #endif
 
@@ -167,8 +159,8 @@ TEST(ThreadControlTest, SetInstructionPointerRedirectsExecution)
 #if !defined(ZYAN_GNUC)
     GTEST_SKIP() << "requires the computed-goto (labels-as-values) extension";
 #else
-    g_ip_stop.store(false);
-    g_ip_reached_end.store(false);
+    g_ip_stop = false;
+    g_ip_reached_end = false;
     g_after_addr = nullptr;
     g_ip_running.store(false);
 
@@ -182,40 +174,24 @@ TEST(ThreadControlTest, SetInstructionPointerRedirectsExecution)
     ZyanUSize n = 0; ZyanVectorGetSize(&ids, &n);
     ASSERT_GE(n, static_cast<ZyanUSize>(1));
 
-    // Suspend the (single) worker and read its IP, retrying until it is caught at one of the two
-    // known-safe points (see the comment above `g_loop_addr`); redirecting from anywhere else
-    // would abandon a live call frame and corrupt the worker's stack.
     const ZyanThreadId id = *reinterpret_cast<const ZyanThreadId*>(ZyanVectorGet(&ids, 0));
+    ASSERT_EQ(ZyanThreadSuspend(id), ZYAN_STATUS_SUCCESS);
+
     ZyanUPointer ip = 0;
-    bool caught_at_safe_point = false;
-    for (int attempt = 0; attempt < 100000; ++attempt)
-    {
-        ASSERT_EQ(ZyanThreadSuspend(id), ZYAN_STATUS_SUCCESS);
-        ASSERT_EQ(ZyanThreadGetInstructionPointer(id, &ip), ZYAN_STATUS_SUCCESS);
-        if ((ip == reinterpret_cast<ZyanUPointer>(g_loop_addr)) ||
-            (ip == reinterpret_cast<ZyanUPointer>(g_safe_after_load_addr)))
-        {
-            caught_at_safe_point = true;
-            break;
-        }
-        ASSERT_EQ(ZyanThreadResume(id), ZYAN_STATUS_SUCCESS);
-        std::this_thread::sleep_for(std::chrono::microseconds(5));
-    }
-    ASSERT_TRUE(caught_at_safe_point);
+    ASSERT_EQ(ZyanThreadGetInstructionPointer(id, &ip), ZYAN_STATUS_SUCCESS);
     EXPECT_NE(ip, static_cast<ZyanUPointer>(0));
 
     ASSERT_EQ(ZyanThreadSetInstructionPointer(id, reinterpret_cast<ZyanUPointer>(g_after_addr)),
         ZYAN_STATUS_SUCCESS);
     ASSERT_EQ(ZyanThreadResume(id), ZYAN_STATUS_SUCCESS);
 
-    // Without ever setting g_ip_stop, the thread must reach the end because we moved its IP.
-    for (int i = 0; (i < 1000) && !g_ip_reached_end.load(); ++i)
+    for (int i = 0; (i < 1000) && !g_ip_reached_end; ++i)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
-    EXPECT_TRUE(g_ip_reached_end.load());
+    EXPECT_TRUE(g_ip_reached_end);
 
-    g_ip_stop.store(true); // safety net if the redirect did not take
+    g_ip_stop = true; // safety net if the redirect did not take
     worker.join();
     ZyanVectorDestroy(&ids);
 #endif

--- a/tests/ThreadControl.cpp
+++ b/tests/ThreadControl.cpp
@@ -72,6 +72,60 @@ TEST(ThreadControlTest, EnumerateFindsSpawnedThreadsAndExcludesCurrent)
     ZyanVectorDestroy(&ids_incl);
 }
 
+TEST(ThreadControlTest, SuspendStopsProgressResumeContinues)
+{
+    std::atomic<bool> stop{false};
+    std::atomic<unsigned long> counter{0};
+    std::atomic<ZyanThreadId> worker_id{0};
+
+    std::thread worker([&]() {
+        ZyanThreadId self = 0;
+        // Publish this thread's enumeration id by finding the one that is not any other.
+        // Simpler: the worker just runs; the test finds the id by enumeration below.
+        ZYAN_UNUSED(self);
+        while (!stop.load()) { counter.fetch_add(1, std::memory_order_relaxed); }
+    });
+
+    // Find the worker's id: enumerate excluding current; there should be exactly one extra
+    // thread that keeps incrementing. We pick the id whose thread is making progress by
+    // suspending each candidate and checking the counter; but to keep it deterministic we
+    // run this test with only the worker as an extra thread.
+    ZyanVector ids;
+    ASSERT_EQ(ZyanVectorInit(&ids, sizeof(ZyanThreadId), 16,
+        reinterpret_cast<ZyanMemberProcedure>(ZYAN_NULL)), ZYAN_STATUS_SUCCESS);
+    // Give the worker a moment to start.
+    while (counter.load() < 1000) { std::this_thread::yield(); }
+    ASSERT_EQ(ZyanThreadEnumerate(&ids, ZYAN_FALSE), ZYAN_STATUS_SUCCESS);
+
+    // Suspend every enumerated thread (gtest has no other busy threads here), then verify the
+    // counter freezes.
+    ZyanUSize n = 0; ZyanVectorGetSize(&ids, &n);
+    for (ZyanUSize i = 0; i < n; ++i)
+    {
+        const ZyanThreadId id = *reinterpret_cast<const ZyanThreadId*>(ZyanVectorGet(&ids, i));
+        ASSERT_EQ(ZyanThreadSuspend(id), ZYAN_STATUS_SUCCESS);
+    }
+
+    const unsigned long a = counter.load();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    const unsigned long b = counter.load();
+    EXPECT_EQ(a, b); // frozen while suspended
+
+    for (ZyanUSize i = 0; i < n; ++i)
+    {
+        const ZyanThreadId id = *reinterpret_cast<const ZyanThreadId*>(ZyanVectorGet(&ids, i));
+        ASSERT_EQ(ZyanThreadResume(id), ZYAN_STATUS_SUCCESS);
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    EXPECT_GT(counter.load(), b); // progressing again after resume
+
+    stop.store(true);
+    worker.join();
+    ZyanVectorDestroy(&ids);
+    ZYAN_UNUSED(worker_id);
+}
+
 int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/tests/ThreadControl.cpp
+++ b/tests/ThreadControl.cpp
@@ -126,6 +126,64 @@ TEST(ThreadControlTest, SuspendStopsProgressResumeContinues)
     ZYAN_UNUSED(worker_id);
 }
 
+// Exposes the address just past its spin loop so the test can redirect the instruction pointer
+// there. `g_after_addr` is published once the thread is spinning.
+static volatile bool          g_ip_stop = false;
+static volatile bool          g_ip_reached_end = false;
+static void*                  g_after_addr = nullptr;
+static std::atomic<bool>      g_ip_running{false};
+
+static void IpSpinTarget()
+{
+    g_after_addr = &&after_loop;      // GCC/Clang labels-as-values extension
+    g_ip_running.store(true);
+loop:
+    if (!g_ip_stop) { goto loop; }
+after_loop:
+    g_ip_reached_end = true;
+}
+
+TEST(ThreadControlTest, SetInstructionPointerRedirectsExecution)
+{
+    g_ip_stop = false;
+    g_ip_reached_end = false;
+    g_after_addr = nullptr;
+    g_ip_running.store(false);
+
+    std::thread worker(IpSpinTarget);
+    while (!g_ip_running.load() || (g_after_addr == nullptr)) { std::this_thread::yield(); }
+
+    ZyanVector ids;
+    ASSERT_EQ(ZyanVectorInit(&ids, sizeof(ZyanThreadId), 16,
+        reinterpret_cast<ZyanMemberProcedure>(ZYAN_NULL)), ZYAN_STATUS_SUCCESS);
+    ASSERT_EQ(ZyanThreadEnumerate(&ids, ZYAN_FALSE), ZYAN_STATUS_SUCCESS);
+    ZyanUSize n = 0; ZyanVectorGetSize(&ids, &n);
+    ASSERT_GE(n, static_cast<ZyanUSize>(1));
+
+    // Suspend the (single) worker, read its IP, redirect it past the loop, resume.
+    const ZyanThreadId id = *reinterpret_cast<const ZyanThreadId*>(ZyanVectorGet(&ids, 0));
+    ASSERT_EQ(ZyanThreadSuspend(id), ZYAN_STATUS_SUCCESS);
+
+    ZyanUPointer ip = 0;
+    ASSERT_EQ(ZyanThreadGetInstructionPointer(id, &ip), ZYAN_STATUS_SUCCESS);
+    EXPECT_NE(ip, static_cast<ZyanUPointer>(0));
+
+    ASSERT_EQ(ZyanThreadSetInstructionPointer(id, reinterpret_cast<ZyanUPointer>(g_after_addr)),
+        ZYAN_STATUS_SUCCESS);
+    ASSERT_EQ(ZyanThreadResume(id), ZYAN_STATUS_SUCCESS);
+
+    // Without ever setting g_ip_stop, the thread must reach the end because we moved its IP.
+    for (int i = 0; (i < 1000) && !g_ip_reached_end; ++i)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    EXPECT_TRUE(g_ip_reached_end);
+
+    g_ip_stop = true; // safety net if the redirect did not take
+    worker.join();
+    ZyanVectorDestroy(&ids);
+}
+
 int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/tests/ThreadControl.cpp
+++ b/tests/ThreadControl.cpp
@@ -128,25 +128,47 @@ TEST(ThreadControlTest, SuspendStopsProgressResumeContinues)
 
 // Exposes the address just past its spin loop so the test can redirect the instruction pointer
 // there. `g_after_addr` is published once the thread is spinning.
-static volatile bool          g_ip_stop = false;
-static volatile bool          g_ip_reached_end = false;
+//
+// Only used by the labels-as-values based spin target below, so the whole block is guarded to
+// avoid unused-variable warnings on compilers that fall into the GTEST_SKIP path.
+#if defined(ZYAN_GNUC)
+static std::atomic<bool>      g_ip_stop{false};
+static std::atomic<bool>      g_ip_reached_end{false};
 static void*                  g_after_addr = nullptr;
 static std::atomic<bool>      g_ip_running{false};
+
+// Two known-safe redirect points within the spin loop: the top of the loop (before the atomic
+// call) and right after `load()` returns. `atomic<bool>::load` is not guaranteed to compile to a
+// single instruction, so a suspend can land inside that call; redirecting RIP away from there
+// would abandon the call's stack frame. The test below retries until it catches the worker at
+// one of these two points, where the stack is guaranteed to match IpSpinTarget's own frame.
+static void*                  g_loop_addr = nullptr;
+static void*                  g_safe_after_load_addr = nullptr;
 
 static void IpSpinTarget()
 {
     g_after_addr = &&after_loop;      // GCC/Clang labels-as-values extension
+    g_loop_addr = &&loop;
+    g_safe_after_load_addr = &&safe_after_load;
     g_ip_running.store(true);
 loop:
-    if (!g_ip_stop) { goto loop; }
+    {
+        const bool stop = g_ip_stop.load();
+    safe_after_load:
+        if (!stop) { goto loop; }
+    }
 after_loop:
-    g_ip_reached_end = true;
+    g_ip_reached_end.store(true);
 }
+#endif
 
 TEST(ThreadControlTest, SetInstructionPointerRedirectsExecution)
 {
-    g_ip_stop = false;
-    g_ip_reached_end = false;
+#if !defined(ZYAN_GNUC)
+    GTEST_SKIP() << "requires the computed-goto (labels-as-values) extension";
+#else
+    g_ip_stop.store(false);
+    g_ip_reached_end.store(false);
     g_after_addr = nullptr;
     g_ip_running.store(false);
 
@@ -160,12 +182,26 @@ TEST(ThreadControlTest, SetInstructionPointerRedirectsExecution)
     ZyanUSize n = 0; ZyanVectorGetSize(&ids, &n);
     ASSERT_GE(n, static_cast<ZyanUSize>(1));
 
-    // Suspend the (single) worker, read its IP, redirect it past the loop, resume.
+    // Suspend the (single) worker and read its IP, retrying until it is caught at one of the two
+    // known-safe points (see the comment above `g_loop_addr`); redirecting from anywhere else
+    // would abandon a live call frame and corrupt the worker's stack.
     const ZyanThreadId id = *reinterpret_cast<const ZyanThreadId*>(ZyanVectorGet(&ids, 0));
-    ASSERT_EQ(ZyanThreadSuspend(id), ZYAN_STATUS_SUCCESS);
-
     ZyanUPointer ip = 0;
-    ASSERT_EQ(ZyanThreadGetInstructionPointer(id, &ip), ZYAN_STATUS_SUCCESS);
+    bool caught_at_safe_point = false;
+    for (int attempt = 0; attempt < 100000; ++attempt)
+    {
+        ASSERT_EQ(ZyanThreadSuspend(id), ZYAN_STATUS_SUCCESS);
+        ASSERT_EQ(ZyanThreadGetInstructionPointer(id, &ip), ZYAN_STATUS_SUCCESS);
+        if ((ip == reinterpret_cast<ZyanUPointer>(g_loop_addr)) ||
+            (ip == reinterpret_cast<ZyanUPointer>(g_safe_after_load_addr)))
+        {
+            caught_at_safe_point = true;
+            break;
+        }
+        ASSERT_EQ(ZyanThreadResume(id), ZYAN_STATUS_SUCCESS);
+        std::this_thread::sleep_for(std::chrono::microseconds(5));
+    }
+    ASSERT_TRUE(caught_at_safe_point);
     EXPECT_NE(ip, static_cast<ZyanUPointer>(0));
 
     ASSERT_EQ(ZyanThreadSetInstructionPointer(id, reinterpret_cast<ZyanUPointer>(g_after_addr)),
@@ -173,15 +209,16 @@ TEST(ThreadControlTest, SetInstructionPointerRedirectsExecution)
     ASSERT_EQ(ZyanThreadResume(id), ZYAN_STATUS_SUCCESS);
 
     // Without ever setting g_ip_stop, the thread must reach the end because we moved its IP.
-    for (int i = 0; (i < 1000) && !g_ip_reached_end; ++i)
+    for (int i = 0; (i < 1000) && !g_ip_reached_end.load(); ++i)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
-    EXPECT_TRUE(g_ip_reached_end);
+    EXPECT_TRUE(g_ip_reached_end.load());
 
-    g_ip_stop = true; // safety net if the redirect did not take
+    g_ip_stop.store(true); // safety net if the redirect did not take
     worker.join();
     ZyanVectorDestroy(&ids);
+#endif
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
## Summary

Adds the low-level virtual-memory and thread-control primitives needed for cross-platform inline hooking, plus a few correctness fixes surfaced along the way. Targets Linux, macOS, and Windows on x86-64.

## Intention

The Zyrex hook engine needs to allocate executable trampolines near a target (within +/-2 GiB), query existing page protections, and suspend and redirect threads while a patch is applied. Those capabilities previously existed only implicitly on Windows. This adds portable APIs so the hook engine can run on POSIX.

## Changes

- `ZyanMemoryVirtualAlloc` and `ZyanMemoryVirtualQuery`, including an address hint for near allocation within +/-2 GiB of a target.
- Thread control: `ZyanThreadEnumerate`, `ZyanThreadSuspend` / `ZyanThreadResume`, and get/set instruction pointer, using a realtime-signal park mechanism on Linux.
- Fix `ZyanProcessFlushInstructionCache` on POSIX to use `__builtin___clear_cache` instead of `msync`, which only accepts page-aligned ranges.
- Fix `ZYAN_ALIGN_DOWN` so it no longer misaligns values that are already aligned.
- Bound the `ZyanThreadSuspend` park-wait so it cannot deadlock on a thread that is exiting.

## Notes

These primitives are consumed by the zyan-hook-engine multi-platform inline hooking PR.
